### PR TITLE
Add .par.yaml initialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,36 @@ par control-center
 
 > **Note**: Must be run from outside tmux. Creates a new session and attaches to each workspace in its own pane.
 
+### Automatic Initialization with .par.yaml
+
+`par` can automatically run initialization commands when creating new worktrees. Simply add a `.par.yaml` file to your repository root:
+
+```yaml
+# .par.yaml
+initialization:
+  commands:
+    - name: "Install frontend dependencies"
+      command: "cd frontend && pnpm install"
+      
+    - name: "Setup environment file"
+      command: "cd frontend && cp .env.example .env"
+      condition: "file_exists:frontend/.env.example"
+      
+    - name: "Install backend dependencies"
+      command: "cd backend && uv sync"
+      condition: "directory_exists:backend"
+      
+    # Simple string commands are also supported
+    - "echo 'Workspace initialized!'"
+```
+
+**Supported condition types:**
+- `directory_exists:path` - Check if directory exists
+- `file_exists:path` - Check if file exists  
+- `env:VAR_NAME` - Check if environment variable is set
+
+When you run `par start my-feature`, these commands will automatically execute in the new worktree's tmux session.
+
 ## Advanced Usage
 
 ### Repository-Scoped Sessions

--- a/par/core.py
+++ b/par/core.py
@@ -10,7 +10,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from . import operations, utils
+from . import initialization, operations, utils
 
 
 # State management - simplified from SessionManager class
@@ -88,6 +88,11 @@ def start_session(label: str):
     # Create resources
     operations.create_worktree(label, worktree_path)
     operations.create_tmux_session(session_name, worktree_path)
+
+    # Run initialization if .par.yaml exists
+    config = initialization.load_par_config(repo_root)
+    if config:
+        initialization.run_initialization(config, session_name)
 
     # Update state
     sessions[label] = {

--- a/par/initialization.py
+++ b/par/initialization.py
@@ -1,0 +1,90 @@
+"""Initialization support for .par.yaml configuration files."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import typer
+import yaml
+from rich.console import Console
+
+from . import operations
+
+
+def load_par_config(repo_root: Path) -> Optional[Dict[str, Any]]:
+    """Load .par.yaml configuration from repository root."""
+    config_file = repo_root / ".par.yaml"
+    if not config_file.exists():
+        return None
+
+    try:
+        with open(config_file, "r") as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        typer.secho(f"Warning: Invalid .par.yaml file: {e}", fg="yellow")
+        return None
+    except Exception as e:
+        typer.secho(f"Warning: Could not read .par.yaml: {e}", fg="yellow")
+        return None
+
+
+def run_initialization(config: Dict[str, Any], session_name: str) -> None:
+    """Run initialization commands from .par.yaml configuration."""
+    initialization = config.get("initialization", {})
+    commands = initialization.get("commands", [])
+    
+    if not commands:
+        return
+
+    console = Console()
+    console.print(f"[cyan]Running initialization commands for session '{session_name}'...[/cyan]")
+
+    for i, command_config in enumerate(commands):
+        if isinstance(command_config, str):
+            # Simple string command
+            command = command_config
+            name = f"Command {i + 1}"
+        elif isinstance(command_config, dict):
+            # Structured command with name and optional condition
+            command = command_config.get("command")
+            name = command_config.get("name", f"Command {i + 1}")
+            condition = command_config.get("condition")
+            
+            if not command:
+                typer.secho(f"Warning: Skipping command {i + 1}: no 'command' specified", fg="yellow")
+                continue
+                
+            # Check condition if specified
+            if condition and not _check_condition(condition):
+                console.print(f"[dim]Skipping '{name}': condition '{condition}' not met[/dim]")
+                continue
+        else:
+            typer.secho(f"Warning: Skipping invalid command config at index {i}", fg="yellow")
+            continue
+
+        console.print(f"[green]Running:[/green] {name}")
+        console.print(f"[dim]  Command: {command}[/dim]")
+        
+        try:
+            operations.send_tmux_keys(session_name, command)
+        except Exception as e:
+            typer.secho(f"Error running command '{name}': {e}", fg="red")
+            # Continue with other commands even if one fails
+
+    console.print(f"[green]✅ Initialization complete for session '{session_name}'[/green]")
+
+
+def _check_condition(condition: str) -> bool:
+    """Check if a condition is met. Returns True if condition passes."""
+    if condition.startswith("directory_exists:"):
+        directory = condition.split(":", 1)[1]
+        return Path(directory).is_dir()
+    elif condition.startswith("file_exists:"):
+        file_path = condition.split(":", 1)[1]
+        return Path(file_path).is_file()
+    elif condition.startswith("env:"):
+        env_var = condition.split(":", 1)[1]
+        return os.getenv(env_var) is not None
+    else:
+        typer.secho(f"Warning: Unknown condition type: {condition}", fg="yellow")
+        return True  # Default to running the command if condition is unknown

--- a/par/test_initialization.py
+++ b/par/test_initialization.py
@@ -1,0 +1,218 @@
+"""Tests for par initialization functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from . import initialization
+
+
+def test_load_par_config_missing_file():
+    """Test loading config when .par.yaml doesn't exist."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        config = initialization.load_par_config(repo_root)
+        assert config is None
+
+
+def test_load_par_config_valid_yaml():
+    """Test loading valid .par.yaml config."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        config_file = repo_root / ".par.yaml"
+        
+        config_content = """
+initialization:
+  commands:
+    - name: "Install deps"
+      command: "npm install"
+    - "echo hello"
+"""
+        config_file.write_text(config_content)
+        
+        config = initialization.load_par_config(repo_root)
+        assert config is not None
+        assert "initialization" in config
+        assert len(config["initialization"]["commands"]) == 2
+
+
+def test_load_par_config_invalid_yaml():
+    """Test loading invalid YAML."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        config_file = repo_root / ".par.yaml"
+        
+        # Invalid YAML (unclosed bracket)
+        config_file.write_text("initialization:\n  commands: [")
+        
+        config = initialization.load_par_config(repo_root)
+        assert config is None
+
+
+@patch('par.initialization.operations.send_tmux_keys')
+def test_run_initialization_string_commands(mock_send_keys):
+    """Test running simple string commands."""
+    config = {
+        "initialization": {
+            "commands": [
+                "npm install",
+                "echo hello"
+            ]
+        }
+    }
+    
+    initialization.run_initialization(config, "test-session")
+    
+    assert mock_send_keys.call_count == 2
+    mock_send_keys.assert_any_call("test-session", "npm install")
+    mock_send_keys.assert_any_call("test-session", "echo hello")
+
+
+@patch('par.initialization.operations.send_tmux_keys')
+def test_run_initialization_structured_commands(mock_send_keys):
+    """Test running structured commands with names."""
+    config = {
+        "initialization": {
+            "commands": [
+                {
+                    "name": "Install dependencies",
+                    "command": "npm install"
+                },
+                {
+                    "name": "Start server",
+                    "command": "npm start"
+                }
+            ]
+        }
+    }
+    
+    initialization.run_initialization(config, "test-session")
+    
+    assert mock_send_keys.call_count == 2
+    mock_send_keys.assert_any_call("test-session", "npm install")
+    mock_send_keys.assert_any_call("test-session", "npm start")
+
+
+@patch('par.initialization.operations.send_tmux_keys')
+def test_run_initialization_with_conditions(mock_send_keys):
+    """Test running commands with conditions."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create a test directory to satisfy condition
+        test_dir = Path(tmpdir) / "frontend"
+        test_dir.mkdir()
+        
+        with patch('par.initialization.Path') as mock_path:
+            mock_path.return_value.is_dir.return_value = True
+            
+            config = {
+                "initialization": {
+                    "commands": [
+                        {
+                            "name": "Install frontend deps",
+                            "command": "cd frontend && npm install",
+                            "condition": "directory_exists:frontend"
+                        },
+                        {
+                            "name": "Install backend deps", 
+                            "command": "cd backend && pip install -r requirements.txt",
+                            "condition": "directory_exists:backend"
+                        }
+                    ]
+                }
+            }
+            
+            # Mock only the second condition to fail
+            def side_effect(path):
+                mock_path_obj = Mock()
+                mock_path_obj.is_dir.return_value = path == "frontend"
+                return mock_path_obj
+                
+            mock_path.side_effect = side_effect
+            
+            initialization.run_initialization(config, "test-session")
+            
+            # Only first command should run due to condition
+            assert mock_send_keys.call_count == 1
+            mock_send_keys.assert_called_with("test-session", "cd frontend && npm install")
+
+
+def test_check_condition_directory_exists():
+    """Test directory_exists condition."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_dir = Path(tmpdir) / "test"
+        test_dir.mkdir()
+        
+        with patch('par.initialization.Path') as mock_path:
+            mock_path.return_value.is_dir.return_value = True
+            result = initialization._check_condition("directory_exists:test")
+            assert result is True
+            
+            mock_path.return_value.is_dir.return_value = False
+            result = initialization._check_condition("directory_exists:nonexistent")
+            assert result is False
+
+
+def test_check_condition_file_exists():
+    """Test file_exists condition."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.txt"
+        test_file.write_text("test")
+        
+        with patch('par.initialization.Path') as mock_path:
+            mock_path.return_value.is_file.return_value = True
+            result = initialization._check_condition("file_exists:test.txt")
+            assert result is True
+            
+            mock_path.return_value.is_file.return_value = False
+            result = initialization._check_condition("file_exists:nonexistent.txt")
+            assert result is False
+
+
+@patch.dict('os.environ', {'TEST_VAR': 'value'})
+def test_check_condition_env_exists():
+    """Test env condition."""
+    result = initialization._check_condition("env:TEST_VAR")
+    assert result is True
+    
+    result = initialization._check_condition("env:NONEXISTENT_VAR")
+    assert result is False
+
+
+def test_check_condition_unknown():
+    """Test unknown condition type."""
+    result = initialization._check_condition("unknown:test")
+    assert result is True  # Should default to True
+
+
+@patch('par.initialization.operations.send_tmux_keys')
+def test_run_initialization_no_commands(mock_send_keys):
+    """Test with no initialization commands."""
+    config = {"other": "settings"}
+    
+    initialization.run_initialization(config, "test-session")
+    
+    assert mock_send_keys.call_count == 0
+
+
+@patch('par.initialization.operations.send_tmux_keys')
+def test_run_initialization_invalid_command_config(mock_send_keys):
+    """Test handling invalid command configurations."""
+    config = {
+        "initialization": {
+            "commands": [
+                "valid command",
+                {"name": "Missing command"},  # No command field
+                123,  # Invalid type
+                {"command": "valid command"}  # Valid
+            ]
+        }
+    }
+    
+    initialization.run_initialization(config, "test-session")
+    
+    # Should only run the valid commands
+    assert mock_send_keys.call_count == 2
+    mock_send_keys.assert_any_call("test-session", "valid command")
+    mock_send_keys.assert_any_call("test-session", "valid command")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [ { name="Victor", email="vimota@gmail.com" } ]
 requires-python = ">=3.12"
 dependencies = [
     "typer",
+    "pyyaml",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary

- Adds automatic workspace initialization via `.par.yaml` configuration files
- Enables project-specific setup commands to run when creating new par sessions
- Supports conditional execution based on directory/file existence and environment variables

## Key Features

- **YAML Configuration**: Define initialization commands in `.par.yaml` at repo root
- **Flexible Commands**: Support both simple strings and structured commands with names
- **Conditional Execution**: Commands can have conditions like `directory_exists:frontend`
- **Comprehensive Testing**: Full test suite covering all functionality
- **Rich Output**: Clear feedback during initialization with command names and progress

## Example Usage

```yaml
# .par.yaml
initialization:
  commands:
    - name: "Install frontend dependencies"
      command: "cd frontend && pnpm install"
      
    - name: "Setup environment file"
      command: "cd frontend && cp .env.example .env"
      condition: "file_exists:frontend/.env.example"
      
    - name: "Install backend dependencies"
      command: "cd backend && uv sync"
      condition: "directory_exists:backend"
```
