### PR TITLE
Add --open flag to par start command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/example.par.yaml
+++ b/example.par.yaml
@@ -1,0 +1,32 @@
+# Example .par.yaml configuration file
+# Place this file in your repository root to customize par initialization
+
+initialization:
+  commands:
+    # Example: Install frontend dependencies in the frontend/ directory
+    - name: "Install frontend dependencies"
+      command: "pnpm install"
+      working_directory: "frontend"
+
+    # Example: Setup environment file in frontend/ directory
+    - name: "Setup environment file"
+      command: "echo 'VITE_API_URL=http://localhost:3000' > .env"
+      working_directory: "frontend"
+
+    # Example: Install backend dependencies in the backend/ directory
+    - name: "Install backend dependencies"
+      command: "uv sync"
+      working_directory: "backend"
+    
+    # Example: Run a global command (no working_directory specified)
+    - name: "Show repository status"
+      command: "git status"
+
+    # Example: Command with condition
+    - name: "Build frontend if package.json exists"
+      command: "npm run build"
+      working_directory: "frontend"
+      condition: "file_exists:frontend/package.json"
+
+# Note: The working_directory is relative to the worktree root
+# Commands without working_directory run in the worktree root

--- a/par/checkout.py
+++ b/par/checkout.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 @dataclass
 class CheckoutStrategy:
     """Strategy for checking out different types of targets."""
+
     ref: str
     remote: str = "origin"
     fetch_remote: bool = False
@@ -17,63 +18,67 @@ class CheckoutStrategy:
 
 def parse_checkout_target(target: str) -> Tuple[str, CheckoutStrategy]:
     """Parse various target formats into branch name and checkout strategy."""
-    
+
     # PR by number: pr/123
     if target.startswith("pr/"):
         pr_number = target[3:]
         if not pr_number.isdigit():
             raise ValueError(f"Invalid PR number: {pr_number}")
         return f"pr-{pr_number}", CheckoutStrategy(
-            ref=f"origin/pull/{pr_number}/head",
-            fetch_remote=True,
-            is_pr=True
+            ref=f"origin/pull/{pr_number}/head", fetch_remote=True, is_pr=True
         )
-    
+
     # PR by URL: https://github.com/owner/repo/pull/123
-    if "github.com" in target and "/pull/" in target:
+    if "github.com" in target:
         try:
             parsed = urlparse(target)
             path_parts = parsed.path.strip("/").split("/")
-            if len(path_parts) >= 4 and path_parts[2] == "pull":
-                pr_number = path_parts[3].split("?")[0]  # Remove query params
-                if not pr_number.isdigit():
-                    raise ValueError(f"Invalid PR number in URL: {pr_number}")
-                return f"pr-{pr_number}", CheckoutStrategy(
-                    ref=f"origin/pull/{pr_number}/head",
-                    fetch_remote=True,
-                    is_pr=True
-                )
+
+            # Check if it's a valid GitHub URL structure
+            if len(path_parts) >= 4:
+                if path_parts[2] == "pull":
+                    pr_number = path_parts[3].split("?")[0]  # Remove query params
+                    if not pr_number.isdigit():
+                        raise ValueError(f"Invalid PR number in URL: {pr_number}")
+                    return f"pr-{pr_number}", CheckoutStrategy(
+                        ref=f"origin/pull/{pr_number}/head",
+                        fetch_remote=True,
+                        is_pr=True,
+                    )
+                else:
+                    # It's a GitHub URL but not a pull request
+                    raise ValueError(f"Could not parse PR URL: {target}")
+            else:
+                raise ValueError(f"Could not parse PR URL: {target}")
+        except ValueError:
+            # Re-raise ValueError as-is
+            raise
         except Exception as e:
             raise ValueError(f"Invalid GitHub PR URL: {target}") from e
-        raise ValueError(f"Could not parse PR URL: {target}")
-    
+
     # Remote branch: username:branch-name or remote/branch-name
     if ":" in target and not target.startswith("http"):
         remote_user, branch = target.split(":", 1)
         if not remote_user or not branch:
             raise ValueError(f"Invalid remote branch format: {target}")
         return generate_label_from_branch(branch), CheckoutStrategy(
-            ref=f"{remote_user}/{branch}",
-            remote=remote_user,
-            fetch_remote=True
+            ref=f"{remote_user}/{branch}", remote=remote_user, fetch_remote=True
         )
-    
+
     # Remote branch with slash: remote/branch-name
     if "/" in target and not target.startswith("origin/"):
         parts = target.split("/", 1)
         if len(parts) == 2:
             remote, branch = parts
             return generate_label_from_branch(branch), CheckoutStrategy(
-                ref=target,
-                remote=remote,
-                fetch_remote=True
+                ref=target, remote=remote, fetch_remote=True
             )
-    
+
     # Simple branch name (local or origin/branch)
     branch_name = target
     if target.startswith("origin/"):
         branch_name = target[7:]  # Remove "origin/" prefix
-    
+
     return generate_label_from_branch(branch_name), CheckoutStrategy(ref=target)
 
 
@@ -86,9 +91,9 @@ def generate_label_from_branch(branch_name: str) -> str:
     label = re.sub(r"[^a-z0-9-]", "", label)
     # Remove leading/trailing hyphens and collapse multiple hyphens
     label = re.sub(r"-+", "-", label).strip("-")
-    
+
     # Ensure we have a valid label
     if not label:
         label = "session"
-    
+
     return label

--- a/par/cli.py
+++ b/par/cli.py
@@ -1,6 +1,7 @@
 # src/par/cli.py
-import typer
 from typing import Optional
+
+import typer
 from typing_extensions import Annotated
 
 from . import core
@@ -108,8 +109,9 @@ def checkout(
     label: Annotated[
         Optional[str],
         typer.Option(
-            "--label", "-l",
-            help="Custom label for the session (defaults to branch name)"
+            "--label",
+            "-l",
+            help="Custom label for the session (defaults to branch name)",
         ),
     ] = None,
 ):

--- a/par/cli.py
+++ b/par/cli.py
@@ -46,12 +46,18 @@ def start(
             help="A unique label for the new worktree, branch, and tmux session."
         ),
     ],
+    open_session: Annotated[
+        bool,
+        typer.Option(
+            "--open", help="Automatically open/attach to the session after creation."
+        ),
+    ] = False,
 ):
     """
     Start a new git worktree and tmux session.
     Creates a worktree, a git branch (both named <label>), and a tmux session.
     """
-    core.start_session(label)
+    core.start_session(label, open_session=open_session)
 
 
 @app.command()

--- a/par/core.py
+++ b/par/core.py
@@ -10,7 +10,8 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from . import initialization, checkout, operations, utils
+from . import checkout, initialization, operations, utils
+
 
 # State management - simplified from SessionManager class
 def _get_state_file() -> Path:
@@ -91,7 +92,7 @@ def start_session(label: str):
     # Run initialization if .par.yaml exists
     config = initialization.load_par_config(repo_root)
     if config:
-        initialization.run_initialization(config, session_name)
+        initialization.run_initialization(config, session_name, worktree_path)
 
     # Update state
     sessions[label] = {
@@ -126,7 +127,7 @@ def remove_session(label: str):
     # Clean up resources
     operations.kill_tmux_session(session_data["tmux_session_name"])
     operations.remove_worktree(Path(session_data["worktree_path"]))
-    
+
     # Only delete branch if it was created by par (not checkout)
     if not session_data.get("is_checkout", False):
         operations.delete_branch(session_data["branch_name"])
@@ -259,17 +260,17 @@ def open_session(label: str):
 def checkout_session(target: str, custom_label: Optional[str] = None):
     """Checkout existing branch or PR into new session."""
     sessions = _get_repo_sessions()
-    
+
     try:
         # Parse target to determine branch name and checkout strategy
         branch_name, strategy = checkout.parse_checkout_target(target)
     except ValueError as e:
         typer.secho(f"Error: {e}", fg="red", err=True)
         raise typer.Exit(1)
-    
+
     # Generate label (custom or derived from branch name)
     label = custom_label or branch_name
-    
+
     if label in sessions:
         typer.secho(f"Error: Session '{label}' already exists.", fg="red", err=True)
         raise typer.Exit(1)
@@ -305,7 +306,9 @@ def checkout_session(target: str, custom_label: Optional[str] = None):
     _update_repo_sessions(sessions)
 
     typer.secho(
-        f"Successfully checked out '{target}' as session '{label}'.", fg="bright_green", bold=True
+        f"Successfully checked out '{target}' as session '{label}'.",
+        fg="bright_green",
+        bold=True,
     )
     typer.echo(f"  Worktree: {worktree_path}")
     typer.echo(f"  Branch: {branch_name}")

--- a/par/core.py
+++ b/par/core.py
@@ -62,7 +62,7 @@ def _update_repo_sessions(sessions: Dict[str, Any]):
 
 
 # Session operations - simplified from actions.py
-def start_session(label: str):
+def start_session(label: str, open_session: bool = False):
     """Start a new git worktree and tmux session."""
     sessions = _get_repo_sessions()
 
@@ -109,7 +109,12 @@ def start_session(label: str):
     typer.echo(f"  Worktree: {worktree_path}")
     typer.echo(f"  Branch: {label}")
     typer.echo(f"  Session: {session_name}")
-    typer.echo(f"To open: par open {label}")
+
+    if open_session:
+        typer.echo("Opening session...")
+        operations.open_tmux_session(session_name)
+    else:
+        typer.echo(f"To open: par open {label}")
 
 
 def remove_session(label: str):

--- a/par/test_checkout.py
+++ b/par/test_checkout.py
@@ -8,7 +8,7 @@ from . import checkout
 def test_parse_pr_number():
     """Test parsing PR by number."""
     branch_name, strategy = checkout.parse_checkout_target("pr/123")
-    
+
     assert branch_name == "pr-123"
     assert strategy.ref == "origin/pull/123/head"
     assert strategy.fetch_remote is True
@@ -19,7 +19,7 @@ def test_parse_pr_url():
     """Test parsing GitHub PR URL."""
     url = "https://github.com/owner/repo/pull/456"
     branch_name, strategy = checkout.parse_checkout_target(url)
-    
+
     assert branch_name == "pr-456"
     assert strategy.ref == "origin/pull/456/head"
     assert strategy.fetch_remote is True
@@ -30,7 +30,7 @@ def test_parse_pr_url_with_params():
     """Test parsing GitHub PR URL with query parameters."""
     url = "https://github.com/owner/repo/pull/789?tab=files"
     branch_name, strategy = checkout.parse_checkout_target(url)
-    
+
     assert branch_name == "pr-789"
     assert strategy.ref == "origin/pull/789/head"
 
@@ -38,7 +38,7 @@ def test_parse_pr_url_with_params():
 def test_parse_remote_branch_colon():
     """Test parsing remote branch with colon format."""
     branch_name, strategy = checkout.parse_checkout_target("alice:feature-branch")
-    
+
     assert branch_name == "feature-branch"
     assert strategy.ref == "alice/feature-branch"
     assert strategy.remote == "alice"
@@ -48,7 +48,7 @@ def test_parse_remote_branch_colon():
 def test_parse_remote_branch_slash():
     """Test parsing remote branch with slash format."""
     branch_name, strategy = checkout.parse_checkout_target("upstream/develop")
-    
+
     assert branch_name == "develop"
     assert strategy.ref == "upstream/develop"
     assert strategy.remote == "upstream"
@@ -58,7 +58,7 @@ def test_parse_remote_branch_slash():
 def test_parse_origin_branch():
     """Test parsing origin branch."""
     branch_name, strategy = checkout.parse_checkout_target("origin/feature")
-    
+
     assert branch_name == "feature"
     assert strategy.ref == "origin/feature"
     assert strategy.remote == "origin"
@@ -68,7 +68,7 @@ def test_parse_origin_branch():
 def test_parse_simple_branch():
     """Test parsing simple local branch name."""
     branch_name, strategy = checkout.parse_checkout_target("main")
-    
+
     assert branch_name == "main"
     assert strategy.ref == "main"
     assert strategy.remote == "origin"
@@ -91,7 +91,7 @@ def test_parse_invalid_remote_format():
     """Test parsing invalid remote format."""
     with pytest.raises(ValueError, match="Invalid remote branch format"):
         checkout.parse_checkout_target(":")
-        
+
     with pytest.raises(ValueError, match="Invalid remote branch format"):
         checkout.parse_checkout_target("alice:")
 
@@ -100,25 +100,25 @@ def test_generate_label_from_branch():
     """Test label generation from branch names."""
     # Normal branch
     assert checkout.generate_label_from_branch("feature-branch") == "feature-branch"
-    
+
     # Branch with slashes
     assert checkout.generate_label_from_branch("feature/new-ui") == "feature-new-ui"
-    
+
     # Branch with underscores
     assert checkout.generate_label_from_branch("bug_fix_123") == "bug-fix-123"
-    
+
     # Mixed case
     assert checkout.generate_label_from_branch("Feature-Branch") == "feature-branch"
-    
+
     # Special characters
     assert checkout.generate_label_from_branch("fix@issue#123") == "fixissue123"
-    
+
     # Multiple consecutive separators
     assert checkout.generate_label_from_branch("feature//new___ui") == "feature-new-ui"
-    
+
     # Leading/trailing separators
     assert checkout.generate_label_from_branch("/feature-branch/") == "feature-branch"
-    
+
     # Empty result
     assert checkout.generate_label_from_branch("@#$%") == "session"
 
@@ -127,38 +127,35 @@ def test_generate_label_edge_cases():
     """Test edge cases for label generation."""
     # Only separators
     assert checkout.generate_label_from_branch("///___") == "session"
-    
+
     # Empty string
     assert checkout.generate_label_from_branch("") == "session"
-    
+
     # Single character
     assert checkout.generate_label_from_branch("a") == "a"
-    
+
     # Numbers only
     assert checkout.generate_label_from_branch("123") == "123"
 
 
 class TestCheckoutStrategy:
     """Test CheckoutStrategy dataclass."""
-    
+
     def test_default_values(self):
         """Test default strategy values."""
         strategy = checkout.CheckoutStrategy(ref="main")
-        
+
         assert strategy.ref == "main"
         assert strategy.remote == "origin"
         assert strategy.fetch_remote is False
         assert strategy.is_pr is False
-    
+
     def test_custom_values(self):
         """Test custom strategy values."""
         strategy = checkout.CheckoutStrategy(
-            ref="feature/branch",
-            remote="upstream", 
-            fetch_remote=True,
-            is_pr=True
+            ref="feature/branch", remote="upstream", fetch_remote=True, is_pr=True
         )
-        
+
         assert strategy.ref == "feature/branch"
         assert strategy.remote == "upstream"
         assert strategy.fetch_remote is True

--- a/par/test_initialization.py
+++ b/par/test_initialization.py
@@ -4,8 +4,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-import pytest
-
 from . import initialization
 
 
@@ -22,7 +20,7 @@ def test_load_par_config_valid_yaml():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_root = Path(tmpdir)
         config_file = repo_root / ".par.yaml"
-        
+
         config_content = """
 initialization:
   commands:
@@ -31,7 +29,7 @@ initialization:
     - "echo hello"
 """
         config_file.write_text(config_content)
-        
+
         config = initialization.load_par_config(repo_root)
         assert config is not None
         assert "initialization" in config
@@ -43,99 +41,91 @@ def test_load_par_config_invalid_yaml():
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_root = Path(tmpdir)
         config_file = repo_root / ".par.yaml"
-        
+
         # Invalid YAML (unclosed bracket)
         config_file.write_text("initialization:\n  commands: [")
-        
+
         config = initialization.load_par_config(repo_root)
         assert config is None
 
 
-@patch('par.initialization.operations.send_tmux_keys')
+@patch("par.initialization.operations.send_tmux_keys")
 def test_run_initialization_string_commands(mock_send_keys):
     """Test running simple string commands."""
-    config = {
-        "initialization": {
-            "commands": [
-                "npm install",
-                "echo hello"
-            ]
-        }
-    }
-    
-    initialization.run_initialization(config, "test-session")
-    
+    config = {"initialization": {"commands": ["npm install", "echo hello"]}}
+
+    worktree_path = Path("/tmp/test-worktree")
+    initialization.run_initialization(config, "test-session", worktree_path)
+
     assert mock_send_keys.call_count == 2
     mock_send_keys.assert_any_call("test-session", "npm install")
     mock_send_keys.assert_any_call("test-session", "echo hello")
 
 
-@patch('par.initialization.operations.send_tmux_keys')
+@patch("par.initialization.operations.send_tmux_keys")
 def test_run_initialization_structured_commands(mock_send_keys):
     """Test running structured commands with names."""
     config = {
         "initialization": {
             "commands": [
-                {
-                    "name": "Install dependencies",
-                    "command": "npm install"
-                },
-                {
-                    "name": "Start server",
-                    "command": "npm start"
-                }
+                {"name": "Install dependencies", "command": "npm install"},
+                {"name": "Start server", "command": "npm start"},
             ]
         }
     }
-    
-    initialization.run_initialization(config, "test-session")
-    
+
+    worktree_path = Path("/tmp/test-worktree")
+    initialization.run_initialization(config, "test-session", worktree_path)
+
     assert mock_send_keys.call_count == 2
     mock_send_keys.assert_any_call("test-session", "npm install")
     mock_send_keys.assert_any_call("test-session", "npm start")
 
 
-@patch('par.initialization.operations.send_tmux_keys')
+@patch("par.initialization.operations.send_tmux_keys")
 def test_run_initialization_with_conditions(mock_send_keys):
     """Test running commands with conditions."""
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create a test directory to satisfy condition
         test_dir = Path(tmpdir) / "frontend"
         test_dir.mkdir()
-        
-        with patch('par.initialization.Path') as mock_path:
+
+        with patch("par.initialization.Path") as mock_path:
             mock_path.return_value.is_dir.return_value = True
-            
+
             config = {
                 "initialization": {
                     "commands": [
                         {
                             "name": "Install frontend deps",
                             "command": "cd frontend && npm install",
-                            "condition": "directory_exists:frontend"
+                            "condition": "directory_exists:frontend",
                         },
                         {
-                            "name": "Install backend deps", 
+                            "name": "Install backend deps",
                             "command": "cd backend && pip install -r requirements.txt",
-                            "condition": "directory_exists:backend"
-                        }
+                            "condition": "directory_exists:backend",
+                        },
                     ]
                 }
             }
-            
+
             # Mock only the second condition to fail
             def side_effect(path):
                 mock_path_obj = Mock()
                 mock_path_obj.is_dir.return_value = path == "frontend"
                 return mock_path_obj
-                
+
             mock_path.side_effect = side_effect
-            
-            initialization.run_initialization(config, "test-session")
-            
+
+            worktree_path = Path(tmpdir)
+            initialization.run_initialization(config, "test-session", worktree_path)
+
             # Only first command should run due to condition
             assert mock_send_keys.call_count == 1
-            mock_send_keys.assert_called_with("test-session", "cd frontend && npm install")
+            mock_send_keys.assert_called_with(
+                "test-session", "cd frontend && npm install"
+            )
 
 
 def test_check_condition_directory_exists():
@@ -143,14 +133,19 @@ def test_check_condition_directory_exists():
     with tempfile.TemporaryDirectory() as tmpdir:
         test_dir = Path(tmpdir) / "test"
         test_dir.mkdir()
-        
-        with patch('par.initialization.Path') as mock_path:
+
+        with patch("par.initialization.Path") as mock_path:
             mock_path.return_value.is_dir.return_value = True
-            result = initialization._check_condition("directory_exists:test")
+            worktree_path = Path(tmpdir)
+            result = initialization._check_condition(
+                "directory_exists:test", worktree_path
+            )
             assert result is True
-            
+
             mock_path.return_value.is_dir.return_value = False
-            result = initialization._check_condition("directory_exists:nonexistent")
+            result = initialization._check_condition(
+                "directory_exists:nonexistent", worktree_path
+            )
             assert result is False
 
 
@@ -159,44 +154,52 @@ def test_check_condition_file_exists():
     with tempfile.TemporaryDirectory() as tmpdir:
         test_file = Path(tmpdir) / "test.txt"
         test_file.write_text("test")
-        
-        with patch('par.initialization.Path') as mock_path:
+
+        with patch("par.initialization.Path") as mock_path:
             mock_path.return_value.is_file.return_value = True
-            result = initialization._check_condition("file_exists:test.txt")
+            worktree_path = Path(tmpdir)
+            result = initialization._check_condition(
+                "file_exists:test.txt", worktree_path
+            )
             assert result is True
-            
+
             mock_path.return_value.is_file.return_value = False
-            result = initialization._check_condition("file_exists:nonexistent.txt")
+            result = initialization._check_condition(
+                "file_exists:nonexistent.txt", worktree_path
+            )
             assert result is False
 
 
-@patch.dict('os.environ', {'TEST_VAR': 'value'})
+@patch.dict("os.environ", {"TEST_VAR": "value"})
 def test_check_condition_env_exists():
     """Test env condition."""
-    result = initialization._check_condition("env:TEST_VAR")
+    worktree_path = Path("/tmp")
+    result = initialization._check_condition("env:TEST_VAR", worktree_path)
     assert result is True
-    
-    result = initialization._check_condition("env:NONEXISTENT_VAR")
+
+    result = initialization._check_condition("env:NONEXISTENT_VAR", worktree_path)
     assert result is False
 
 
 def test_check_condition_unknown():
     """Test unknown condition type."""
-    result = initialization._check_condition("unknown:test")
+    worktree_path = Path("/tmp")
+    result = initialization._check_condition("unknown:test", worktree_path)
     assert result is True  # Should default to True
 
 
-@patch('par.initialization.operations.send_tmux_keys')
+@patch("par.initialization.operations.send_tmux_keys")
 def test_run_initialization_no_commands(mock_send_keys):
     """Test with no initialization commands."""
     config = {"other": "settings"}
-    
-    initialization.run_initialization(config, "test-session")
-    
+
+    worktree_path = Path("/tmp/test-worktree")
+    initialization.run_initialization(config, "test-session", worktree_path)
+
     assert mock_send_keys.call_count == 0
 
 
-@patch('par.initialization.operations.send_tmux_keys')
+@patch("par.initialization.operations.send_tmux_keys")
 def test_run_initialization_invalid_command_config(mock_send_keys):
     """Test handling invalid command configurations."""
     config = {
@@ -205,14 +208,45 @@ def test_run_initialization_invalid_command_config(mock_send_keys):
                 "valid command",
                 {"name": "Missing command"},  # No command field
                 123,  # Invalid type
-                {"command": "valid command"}  # Valid
+                {"command": "valid command"},  # Valid
             ]
         }
     }
-    
-    initialization.run_initialization(config, "test-session")
-    
+
+    worktree_path = Path("/tmp/test-worktree")
+    initialization.run_initialization(config, "test-session", worktree_path)
+
     # Should only run the valid commands
     assert mock_send_keys.call_count == 2
     mock_send_keys.assert_any_call("test-session", "valid command")
     mock_send_keys.assert_any_call("test-session", "valid command")
+
+
+@patch("par.initialization.operations.send_tmux_keys")
+def test_run_initialization_with_working_directory(mock_send_keys):
+    """Test running commands with working_directory specified."""
+    config = {
+        "initialization": {
+            "commands": [
+                {
+                    "name": "Install frontend deps",
+                    "command": "pnpm install",
+                    "working_directory": "frontend",
+                },
+                {
+                    "name": "Install backend deps",
+                    "command": "uv sync",
+                    "working_directory": "backend",
+                },
+                "echo 'global command'",  # No working directory
+            ]
+        }
+    }
+
+    worktree_path = Path("/tmp/test-worktree")
+    initialization.run_initialization(config, "test-session", worktree_path)
+
+    assert mock_send_keys.call_count == 3
+    mock_send_keys.assert_any_call("test-session", "cd frontend && pnpm install")
+    mock_send_keys.assert_any_call("test-session", "cd backend && uv sync")
+    mock_send_keys.assert_any_call("test-session", "echo 'global command'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,20 @@ dependencies = [
     "pyyaml",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "ruff",
+    "pre-commit",
+]
+
 [tool.uv]
 package = true
+dev-dependencies = [
+    "pytest",
+    "ruff", 
+    "pre-commit",
+]
 
 [project.scripts]
 par = "par.cli:app"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+# Extend default lint rules.
+# TODO: Enable "UP007", "UP045" to lint Typing.Optional/Union
+extend-select = ["I", "E", "PLC", "PLE"]
+ignore = ["E501"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 2
+revision = 1
 requires-python = ">=3.12"
+
+[[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
 
 [[package]]
 name = "click"
@@ -9,18 +18,54 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215 },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "distlib"
+version = "0.3.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+]
+
+[[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
 
 [[package]]
@@ -30,18 +75,36 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
 ]
 
 [[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
@@ -49,19 +112,124 @@ name = "par"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pyyaml" },
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "typer" }]
+requires-dist = [
+    { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pyyaml" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "typer" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707 },
+]
 
 [[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797 },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/0c/c581167fc46d6d6d7ddcfb8c843a4de25bdd27e4466938109ca68492292c/PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab", size = 183873 },
+    { url = "https://files.pythonhosted.org/packages/a8/0c/38374f5bb272c051e2a69281d71cba6fdb983413e6758b84482905e29a5d/PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725", size = 173302 },
+    { url = "https://files.pythonhosted.org/packages/c3/93/9916574aa8c00aa06bbac729972eb1071d002b8e158bd0e83a3b9a20a1f7/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5", size = 739154 },
+    { url = "https://files.pythonhosted.org/packages/95/0f/b8938f1cbd09739c6da569d172531567dbcc9789e0029aa070856f123984/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425", size = 766223 },
+    { url = "https://files.pythonhosted.org/packages/b9/2b/614b4752f2e127db5cc206abc23a8c19678e92b23c3db30fc86ab731d3bd/PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476", size = 767542 },
+    { url = "https://files.pythonhosted.org/packages/d4/00/dd137d5bcc7efea1836d6264f049359861cf548469d18da90cd8216cf05f/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48", size = 731164 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611 },
+    { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591 },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338 },
+    { url = "https://files.pythonhosted.org/packages/ef/e3/3af305b830494fa85d95f6d95ef7fa73f2ee1cc8ef5b495c7c3269fb835f/PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba", size = 181309 },
+    { url = "https://files.pythonhosted.org/packages/45/9f/3b1c20a0b7a3200524eb0076cc027a970d320bd3a6592873c85c92a08731/PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1", size = 171679 },
+    { url = "https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133", size = 733428 },
+    { url = "https://files.pythonhosted.org/packages/a3/69/864fbe19e6c18ea3cc196cbe5d392175b4cf3d5d0ac1403ec3f2d237ebb5/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484", size = 763361 },
+    { url = "https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5", size = 759523 },
+    { url = "https://files.pythonhosted.org/packages/2b/b2/e3234f59ba06559c6ff63c4e10baea10e5e7df868092bf9ab40e5b9c56b6/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc", size = 726660 },
+    { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
+    { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
+    { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
 ]
 
 [[package]]
@@ -72,18 +240,43 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/0a/92416b159ec00cdf11e5882a9d80d29bf84bba3dbebc51c4898bfbca1da6/ruff-0.11.12.tar.gz", hash = "sha256:43cf7f69c7d7c7d7513b9d59c5d8cafd704e05944f978614aa9faff6ac202603", size = 4202289 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/cc/53eb79f012d15e136d40a8e8fc519ba8f55a057f60b29c2df34efd47c6e3/ruff-0.11.12-py3-none-linux_armv6l.whl", hash = "sha256:c7680aa2f0d4c4f43353d1e72123955c7a2159b8646cd43402de6d4a3a25d7cc", size = 10285597 },
+    { url = "https://files.pythonhosted.org/packages/e7/d7/73386e9fb0232b015a23f62fea7503f96e29c29e6c45461d4a73bac74df9/ruff-0.11.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2cad64843da9f134565c20bcc430642de897b8ea02e2e79e6e02a76b8dcad7c3", size = 11053154 },
+    { url = "https://files.pythonhosted.org/packages/4e/eb/3eae144c5114e92deb65a0cb2c72326c8469e14991e9bc3ec0349da1331c/ruff-0.11.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9b6886b524a1c659cee1758140138455d3c029783d1b9e643f3624a5ee0cb0aa", size = 10403048 },
+    { url = "https://files.pythonhosted.org/packages/29/64/20c54b20e58b1058db6689e94731f2a22e9f7abab74e1a758dfba058b6ca/ruff-0.11.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc3a3690aad6e86c1958d3ec3c38c4594b6ecec75c1f531e84160bd827b2012", size = 10597062 },
+    { url = "https://files.pythonhosted.org/packages/29/3a/79fa6a9a39422a400564ca7233a689a151f1039110f0bbbabcb38106883a/ruff-0.11.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f97fdbc2549f456c65b3b0048560d44ddd540db1f27c778a938371424b49fe4a", size = 10155152 },
+    { url = "https://files.pythonhosted.org/packages/e5/a4/22c2c97b2340aa968af3a39bc38045e78d36abd4ed3fa2bde91c31e712e3/ruff-0.11.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74adf84960236961090e2d1348c1a67d940fd12e811a33fb3d107df61eef8fc7", size = 11723067 },
+    { url = "https://files.pythonhosted.org/packages/bc/cf/3e452fbd9597bcd8058856ecd42b22751749d07935793a1856d988154151/ruff-0.11.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b56697e5b8bcf1d61293ccfe63873aba08fdbcbbba839fc046ec5926bdb25a3a", size = 12460807 },
+    { url = "https://files.pythonhosted.org/packages/2f/ec/8f170381a15e1eb7d93cb4feef8d17334d5a1eb33fee273aee5d1f8241a3/ruff-0.11.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d47afa45e7b0eaf5e5969c6b39cbd108be83910b5c74626247e366fd7a36a13", size = 12063261 },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/57208f8c0a8153a14652a85f4116c0002148e83770d7a41f2e90b52d2b4e/ruff-0.11.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bf9603fe1bf949de8b09a2da896f05c01ed7a187f4a386cdba6760e7f61be", size = 11329601 },
+    { url = "https://files.pythonhosted.org/packages/c3/56/edf942f7fdac5888094d9ffa303f12096f1a93eb46570bcf5f14c0c70880/ruff-0.11.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08033320e979df3b20dba567c62f69c45e01df708b0f9c83912d7abd3e0801cd", size = 11522186 },
+    { url = "https://files.pythonhosted.org/packages/ed/63/79ffef65246911ed7e2290aeece48739d9603b3a35f9529fec0fc6c26400/ruff-0.11.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:929b7706584f5bfd61d67d5070f399057d07c70585fa8c4491d78ada452d3bef", size = 10449032 },
+    { url = "https://files.pythonhosted.org/packages/88/19/8c9d4d8a1c2a3f5a1ea45a64b42593d50e28b8e038f1aafd65d6b43647f3/ruff-0.11.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7de4a73205dc5756b8e09ee3ed67c38312dce1aa28972b93150f5751199981b5", size = 10129370 },
+    { url = "https://files.pythonhosted.org/packages/bc/0f/2d15533eaa18f460530a857e1778900cd867ded67f16c85723569d54e410/ruff-0.11.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2635c2a90ac1b8ca9e93b70af59dfd1dd2026a40e2d6eebaa3efb0465dd9cf02", size = 11123529 },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/4c2ac669534bdded835356813f48ea33cfb3a947dc47f270038364587088/ruff-0.11.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d05d6a78a89166f03f03a198ecc9d18779076ad0eec476819467acb401028c0c", size = 11577642 },
+    { url = "https://files.pythonhosted.org/packages/a7/9b/c9ddf7f924d5617a1c94a93ba595f4b24cb5bc50e98b94433ab3f7ad27e5/ruff-0.11.12-py3-none-win32.whl", hash = "sha256:f5a07f49767c4be4772d161bfc049c1f242db0cfe1bd976e0f0886732a4765d6", size = 10475511 },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/74fb6d3470c1aada019ffff33c0f9210af746cca0a4de19a1f10ce54968a/ruff-0.11.12-py3-none-win_amd64.whl", hash = "sha256:5a4d9f8030d8c3a45df201d7fb3ed38d0219bccd7955268e863ee4a115fa0832", size = 11523573 },
+    { url = "https://files.pythonhosted.org/packages/44/42/d58086ec20f52d2b0140752ae54b355ea2be2ed46f914231136dd1effcc7/ruff-0.11.12-py3-none-win_arm64.whl", hash = "sha256:65194e37853158d368e333ba282217941029a28ea90913c67e558c611d04daa5", size = 10697770 },
 ]
 
 [[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
 ]
 
 [[package]]
@@ -96,16 +289,30 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317 },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982 },
 ]


### PR DESCRIPTION
## Summary
- Add `--open` flag to `par start` command for better UX
- Automatically attach to tmux session after creation when flag is used
- Eliminates need for separate `par open` command in common workflow

## Changes
**CLI enhancement:**
- Added `--open` flag to `par start` command
- Updated `start_session()` function to accept `open_session` parameter  
- Modified output messaging based on whether session is opened automatically

## Usage
```bash
# Traditional workflow (unchanged)
par start my-feature
par open my-feature

# New streamlined workflow  
par start my-feature --open
```

## Test plan
- [x] All existing tests pass (27/27)
- [x] Manual testing of --open flag functionality
- [x] Help command shows new flag correctly
- [x] Backward compatibility maintained (default behavior unchanged)

## Benefits
- Improves user experience by reducing common two-step workflow to one command
- Addresses confusion around initialization output by immediately entering session
- Maintains backward compatibility with existing scripts/workflows