### PR TITLE
Add session label autocompletion

### DIFF
--- a/par/core.py
+++ b/par/core.py
@@ -4,7 +4,7 @@ import datetime
 import json
 import shutil
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 import typer
 from rich.console import Console
@@ -58,6 +58,11 @@ def _update_repo_sessions(sessions: Dict[str, Any]):
         state.pop(repo_key, None)  # Remove empty repo entries
 
     _save_state(state)
+
+
+def get_session_labels() -> List[str]:
+    """Return a sorted list of session labels for the current repository."""
+    return sorted(_get_repo_sessions().keys())
 
 
 # Session operations - simplified from actions.py


### PR DESCRIPTION
## Summary
- support completion by returning session labels from core
- expose completion functions in cli for label and target arguments

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68434317626883328ee3d23aedbd5e23