### PR TITLE
Support copying files into new worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ Shows both single-repo sessions and multi-repo workspaces in separate panes, giv
 ```yaml
 # .par.yaml
 initialization:
+  include:
+    - .env
+    - config/*.json
   commands:
     - name: "Install frontend dependencies"
       command: "cd frontend && pnpm install"
@@ -218,6 +221,8 @@ initialization:
     # Simple string commands are also supported
     - "echo 'Workspace initialized!'"
 ```
+
+Files listed under `include` are copied from the repository root into each new worktree before any commands run. This lets you keep gitignored files like `.env` in the new environment.
 
 All commands start from the worktree root directory. Use `cd <directory> &&` to run commands in subdirectories.
 

--- a/example.par.yaml
+++ b/example.par.yaml
@@ -2,6 +2,8 @@
 # Place this file in your repository root to customize par initialization
 
 initialization:
+  include:
+    - .env
   commands:
     # Example: Install frontend dependencies
     - name: "Install frontend dependencies"

--- a/par/operations.py
+++ b/par/operations.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 import typer
 
 from .checkout import CheckoutStrategy
-from .utils import get_git_repo_root, run_cmd
+from .utils import get_git_repo_root, get_tmux_session_name, run_cmd
 
 
 # Tmux utilities
@@ -203,9 +203,6 @@ def open_control_center(sessions_data: List[dict]):
     if not sessions_data:
         typer.secho("No sessions to display.", fg="yellow")
         return
-
-    # Import here to avoid circular dependency
-    from .utils import get_tmux_session_name
 
     repo_root = get_git_repo_root()
     cc_session_name = get_tmux_session_name(repo_root, "cc")

--- a/par/test_initialization.py
+++ b/par/test_initialization.py
@@ -153,3 +153,20 @@ def test_run_initialization_invalid_command_config(mock_send_keys):
     mock_send_keys.assert_any_call(
         "test-session", "cd /tmp/test-worktree && valid command"
     )
+
+
+def test_copy_included_files(tmp_path):
+    """Files listed under include are copied to the worktree."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    src = repo_root / ".env"
+    src.write_text("SECRET=1")
+
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+
+    config = {"initialization": {"include": [".env"]}}
+    initialization.copy_included_files(config, repo_root, worktree_path)
+
+    dest = worktree_path / ".env"
+    assert dest.exists() and dest.read_text() == "SECRET=1"

--- a/par/workspace.py
+++ b/par/workspace.py
@@ -129,6 +129,13 @@ def start_workspace_session(
         # Create resources
         operations.create_workspace_worktree(repo_path, label, worktree_path)
 
+        # Copy includes for this repository
+        config = initialization.load_par_config(repo_path)
+        if config:
+            initialization.copy_included_files(
+                config, repo_path, worktree_path
+            )
+
         repos_data.append(
             {
                 "repo_name": repo_name,


### PR DESCRIPTION
## Summary
- allow `.par.yaml` to specify `initialization.include` files
- copy included files when starting sessions or workspaces
- document the new `include` section
- add tests for `copy_included_files`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_6872bb0910f8833289ac8f923ceed613