### PR TITLE
POC: New control-center manager CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Tools like OpenAI Codex, Claude Code, and other coding agents have made it easie
 
 https://github.com/user-attachments/assets/88eb4aed-c00d-4238-b1a9-bcaa34c975c3
 
-
-
 ## Key Features
 
 ### 🚀 **Quick Start**
+
 ```bash
 # From within a git repository
 par start feature-auth    # Creates worktree, branch, and tmux session
@@ -36,24 +35,28 @@ par start experiment-ai --path ~/projects/my-app
 ```
 
 ### 📋 **Global Development Context Management**
+
 ```bash
 par ls                    # List ALL sessions and workspaces globally
 par open feature-auth     # Switch to any session or workspace from anywhere
 par rm bugfix-login       # Clean up completed work globally
 ```
 
-### 📡 **Global Remote Execution**  
+### 📡 **Global Remote Execution**
+
 ```bash
 par send feature-auth "pnpm test"           # Run tests in one session
 par send all "git status"                  # Check status across ALL sessions globally
 ```
 
 ### 🎛️ **Global Control Center**
+
 ```bash
 par control-center        # View ALL sessions and workspaces globally in a tiled layout
 ```
 
 ### 🏢 **Multi-Repository Workspaces**
+
 ```bash
 par workspace start feature-auth --repos frontend,backend
 par workspace code feature-auth     # Open in VSCode with multi-repo support
@@ -65,10 +68,12 @@ par workspace open feature-auth     # Attach to unified tmux session
 `par` provides a **unified interface** for managing both single-repository sessions and multi-repository workspaces. Whether you're working on a single feature branch or coordinating changes across multiple repositories, all your development contexts appear in one place.
 
 ### Two Development Modes:
+
 - **Sessions**: Single-repo development with isolated branches (`par start`, `par checkout`)
 - **Workspaces**: Multi-repo development with synchronized branches (`par workspace start`)
 
 ### Unified Commands:
+
 - `par ls` - See all your development contexts (sessions + workspaces) in one table
 - `par open <label>` - Switch to any session or workspace
 - `par control-center` - View all contexts in a tiled tmux layout
@@ -79,8 +84,9 @@ This eliminates the need to remember which type of development context you're wo
 ## Installation
 
 ### Prerequisites
+
 - **Git** - Version control system
-- **tmux** - Terminal multiplexer  
+- **tmux** - Terminal multiplexer
 - **Python 3.12+** - Runtime environment
 - **uv** - Package manager (recommended)
 
@@ -97,6 +103,7 @@ pip install par-cli
 ```
 
 ### Install from Source
+
 ```bash
 git clone https://github.com/coplane/par.git
 cd par
@@ -104,6 +111,7 @@ uv tool install .
 ```
 
 ### Verify Installation
+
 ```bash
 par --version
 par --help
@@ -125,6 +133,7 @@ par start my-feature -p ~/projects/my-app
 ```
 
 This creates:
+
 - Git worktree at `~/.local/share/par/worktrees/<repo-hash>/my-feature/`
 - Git branch named `my-feature`
 - tmux session named `par-<repo>-<hash>-my-feature`
@@ -156,6 +165,7 @@ par checkout pr/123 --path ~/projects/my-app --label pr-review
 ```
 
 **Supported formats:**
+
 - `branch-name` - Local or origin branch
 - `pr/123` - GitHub PR by number
 - `https://github.com/owner/repo/pull/123` - GitHub PR by URL
@@ -165,6 +175,7 @@ par checkout pr/123 --path ~/projects/my-app --label pr-review
 ### Global Development Context Management
 
 **List all sessions and workspaces globally:**
+
 ```bash
 par ls    # Shows ALL sessions and workspaces from anywhere
 ```
@@ -184,12 +195,14 @@ Par Development Contexts (Global)
 ```
 
 **Open any development context from anywhere:**
+
 ```bash
-par open my-feature        # Opens session (works globally)
-par open fullstack-auth    # Opens workspace (works globally)
+par open my-feature        # Opens session
+par open fullstack-auth    # Opens workspace
 ```
 
 **Remove completed work from anywhere:**
+
 ```bash
 par rm my-feature      # Remove specific session/workspace globally
 par rm all             # Remove ALL sessions and workspaces (with confirmation)
@@ -199,7 +212,8 @@ par rm all             # Remove ALL sessions and workspaces (with confirmation)
 
 ### Global Remote Command Execution
 
-**Send commands to specific sessions (works globally):**
+**Send commands to specific sessions :**
+
 ```bash
 par send my-feature "npm install"
 par send backend-work "python manage.py migrate"
@@ -207,6 +221,7 @@ par send workspace-name "git status"    # Works for workspaces too
 ```
 
 **Broadcast to ALL sessions and workspaces globally:**
+
 ```bash
 par send all "git status"    # Sends to every session everywhere
 par send all "npm test"      # Runs tests across all contexts
@@ -237,13 +252,13 @@ initialization:
   commands:
     - name: "Install frontend dependencies"
       command: "cd frontend && pnpm install"
-      
+
     - name: "Setup environment file"
       command: "cd frontend && cp .env.example .env"
-      
+
     - name: "Install backend dependencies"
       command: "cd backend && uv sync"
-      
+
     # Simple string commands are also supported
     - "echo 'Workspace initialized!'"
 ```
@@ -261,6 +276,7 @@ For projects spanning multiple repositories (like frontend/backend splits or mic
 ### Why Workspaces?
 
 When working on features that span multiple repositories, you typically need to:
+
 - Create branches with the same name across repos
 - Keep terminal sessions open for each repo
 - Switch between repositories frequently
@@ -287,26 +303,30 @@ par workspace cursor feature-auth   # Cursor
 ### Workspace Commands
 
 **Create a workspace:**
+
 ```bash
 par workspace start <label> [--path /workspace/root] [--repos repo1,repo2] [--open]
 ```
 
 **List workspaces (now unified with sessions):**
+
 ```bash
 par ls                            # Shows workspaces alongside sessions
 par workspace ls                  # Shows only workspaces (deprecated)
 ```
 
 **Open workspace (now unified):**
+
 ```bash
-par open <label>                  # Opens workspace session (works globally)
-par workspace code <label>        # Open in VSCode  
+par open <label>                  # Opens workspace session
+par workspace code <label>        # Open in VSCode
 par workspace cursor <label>      # Open in Cursor
 ```
 
 **Remove workspace (now unified):**
+
 ```bash
-par rm <label>                    # Remove workspace (works globally)
+par rm <label>                    # Remove workspace
 par workspace rm <label>          # Also works (delegates to global rm)
 ```
 
@@ -321,25 +341,24 @@ When you create a workspace, `par` automatically:
 5. **Integrates with global par commands** - use `par ls`, `par open`, `par rm` etc.
 
 **Example directory structure:**
+
 ```
 # Original repositories anywhere on system:
-/home/user/projects/frontend/     # React app
-/home/user/projects/backend/      # Python API  
-/opt/company/docs/                # Documentation
+my-fullstack-app/
+├── frontend/           # React app
+├── backend/            # Python API
+└── docs/              # Documentation
 
 # After: par workspace start user-auth --repos /home/user/projects/frontend,/home/user/projects/backend,/opt/company/docs
 # Creates unified workspace at: ~/.local/share/par/workspaces/.../user-auth/
 ├── frontend/
-│   └── user-auth/     # Worktree with user-auth branch
 ├── backend/
-│   └── user-auth/     # Worktree with user-auth branch  
 ├── docs/
-│   └── user-auth/     # Worktree with user-auth branch
 └── user-auth.code-workspace
 
 # Single tmux session starts from workspace root
 # Navigate with: cd frontend/, cd backend/, cd docs/
-# Global session accessible via: par open user-auth (from anywhere)
+# Global session accessible via: par open user-auth
 ```
 
 ### IDE Integration
@@ -347,11 +366,13 @@ When you create a workspace, `par` automatically:
 Workspaces include first-class IDE support that solves the common problem of multi-repo development in editors.
 
 **VSCode Integration:**
+
 ```bash
 par workspace code user-auth
 ```
 
 This generates and opens a `.code-workspace` file containing:
+
 ```json
 {
   "folders": [
@@ -360,7 +381,7 @@ This generates and opens a `.code-workspace` file containing:
       "path": "/path/to/worktrees/frontend/user-auth"
     },
     {
-      "name": "backend (user-auth)", 
+      "name": "backend (user-auth)",
       "path": "/path/to/worktrees/backend/user-auth"
     }
   ],
@@ -372,6 +393,7 @@ This generates and opens a `.code-workspace` file containing:
 ```
 
 **Benefits:**
+
 - Each repository appears as a separate folder in the explorer
 - Git operations work correctly for each repository
 - All repositories are on the correct feature branch
@@ -380,18 +402,21 @@ This generates and opens a `.code-workspace` file containing:
 ### Repository Specification
 
 **Auto-detection (recommended):**
+
 ```bash
 par workspace start feature-name
 # Automatically finds all git repositories in current directory
 ```
 
 **Explicit specification:**
+
 ```bash
 par workspace start feature-name --repos frontend,backend,shared
 # Only includes specified repositories
 ```
 
 **Comma-separated syntax:**
+
 ```bash
 --repos repo1,repo2,repo3
 --repos "frontend, backend, docs"    # Spaces are trimmed
@@ -411,7 +436,7 @@ Workspaces are organized separately from single-repo sessions:
             ├── frontend/
             │   └── feature-auth/     # Worktree
             ├── backend/
-            │   └── feature-auth/     # Worktree  
+            │   └── feature-auth/     # Worktree
             └── feature-auth.code-workspace
 ```
 
@@ -444,14 +469,15 @@ Each repository's initialization runs in its own worktree, ensuring proper isola
 ### Example Workflows
 
 **Full-stack feature development:**
+
 ```bash
-# 1. Start workspace for new feature (from anywhere)
+# 1. Start workspace for new feature
 par workspace start user-profiles --repos /path/to/frontend,/path/to/backend
 
 # 2. Open in IDE with proper multi-repo support
 par workspace code user-profiles
 
-# 3. Open unified session (works globally)
+# 3. Open unified session
 par open user-profiles
 
 # 4. Work across repositories from single terminal
@@ -459,22 +485,23 @@ cd frontend/    # Switch to frontend worktree
 cd ../backend/  # Switch to backend worktree
 claude          # Run Claude from workspace root to see all repos
 
-# 5. Global management (works from anywhere)
+# 5. Global management
 par ls                           # See all sessions including workspaces
 par send user-profiles "git status"  # Send commands globally
 
-# 6. Clean up when feature is complete (from anywhere)
+# 6. Clean up when feature is complete
 par rm user-profiles
 ```
 
 **Microservices development:**
+
 ```bash
-# Work on API changes affecting multiple services (absolute paths)
+# Work on API changes affecting multiple services
 par workspace start api-v2 --repos /srv/auth-service,/srv/user-service,/srv/gateway
 
 # All services get api-v2 branch
 # Single global session accessible from anywhere
-# IDE workspace shows all services together  
+# IDE workspace shows all services together
 # Navigate: cd auth-service/, cd user-service/, etc.
 # Global commands: par send api-v2 "docker-compose up"
 ```
@@ -507,6 +534,7 @@ par ls                     # Shows all sessions globally
 ## Configuration
 
 ### Data Directory
+
 Par stores its data in `~/.local/share/par/` (or `$XDG_DATA_HOME/par/`):
 
 ```
@@ -523,11 +551,12 @@ Par stores its data in `~/.local/share/par/` (or `$XDG_DATA_HOME/par/`):
             ├── frontend/
             │   └── feature-auth/     # Worktree
             ├── backend/
-            │   └── feature-auth/     # Worktree  
+            │   └── feature-auth/     # Worktree
             └── feature-auth.code-workspace
 ```
 
 ### Session Naming Convention
+
 tmux sessions follow the pattern: `par-<repo-name>-<repo-hash>-<label>`
 
 Example: `par-myproject-a1b2c3d4-feature-auth`
@@ -535,12 +564,13 @@ Example: `par-myproject-a1b2c3d4-feature-auth`
 ### Cleaning Up
 
 Remove all par-managed resources globally:
+
 ```bash
 par rm all    # Removes ALL sessions and workspaces everywhere
 ```
 
 Remove specific stale sessions:
+
 ```bash
 par rm old-feature-name
 ```
-

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ par send all "git status"                  # Check status across ALL sessions gl
 ### 🎛️ **Global Control Center**
 
 ```bash
-par control-center        # View ALL sessions and workspaces globally in a tiled layout
+par control-center        # View ALL sessions and workspaces globally with separate windows
 ```
 
 ### 🏢 **Multi-Repository Workspaces**
@@ -76,7 +76,7 @@ par workspace open feature-auth     # Attach to unified tmux session
 
 - `par ls` - See all your development contexts (sessions + workspaces) in one table
 - `par open <label>` - Switch to any session or workspace
-- `par control-center` - View all contexts in a tiled tmux layout
+- `par control-center` - View all contexts in separate tmux windows
 - Tab completion works across both sessions and workspaces
 
 This eliminates the need to remember which type of development context you're working with - just use the label and `par` handles the rest!
@@ -229,15 +229,21 @@ par send all "npm test"      # Runs tests across all contexts
 
 ### Global Control Center
 
-View ALL development contexts simultaneously in a tiled tmux layout:
+View ALL development contexts simultaneously with dedicated tmux windows:
 
 ```bash
 par control-center    # Works from anywhere, shows everything
 ```
 
-Shows all sessions and workspaces across all repositories in separate panes, giving you a unified overview of your entire development workflow.
+Creates a unified `control-center` tmux session with separate windows for each development context (sessions and workspace repositories), giving you easy navigation across your entire development workflow.
 
-> **Note**: Must be run from outside tmux. Creates a global control center session with all contexts visible.
+> **Note**: Must be run from outside tmux. Creates a global control center session with dedicated windows for each context.
+
+**Benefits of the windowed approach:**
+- **Easy Navigation**: Use tmux window switching (`Ctrl-b + number` or `Ctrl-b + n/p`) to jump between contexts
+- **Clean Organization**: Each development context gets its own dedicated window with a descriptive name
+- **Scalable**: Works well with many sessions/workspaces (unlike tiled panes that become cramped)
+- **Workspace Support**: For multi-repo workspaces, each repository gets its own window
 
 ### Automatic Initialization with .par.yaml
 

--- a/par/cli.py
+++ b/par/cli.py
@@ -199,6 +199,15 @@ def control_center():
     core.open_control_center()
 
 
+@app.command(name="control-center-new")
+def control_center_new():
+    """
+    Create a new 'control-center' tmux session with separate windows for each par session.
+    Must be run from outside tmux. Shows all sessions and workspaces par knows about.
+    """
+    core.open_control_center_new()
+
+
 # Workspace commands
 workspace_app = typer.Typer(help="Manage multi-repository workspaces")
 app.add_typer(workspace_app, name="workspace")

--- a/par/cli.py
+++ b/par/cli.py
@@ -193,19 +193,10 @@ def open(
 @app.command(name="control-center")
 def control_center():
     """
-    Open all 'par'-managed sessions in a tiled tmux window (control center view).
-    Must be run from within an existing tmux session.
+    Create a new 'control-center' tmux session with separate windows for each par session.
+    Must be run from outside tmux. Shows all sessions and workspaces globally.
     """
     core.open_control_center()
-
-
-@app.command(name="control-center-new")
-def control_center_new():
-    """
-    Create a new 'control-center' tmux session with separate windows for each par session.
-    Must be run from outside tmux. Shows all sessions and workspaces par knows about.
-    """
-    core.open_control_center_new()
 
 
 # Workspace commands

--- a/par/core.py
+++ b/par/core.py
@@ -532,10 +532,8 @@ def open_control_center():
     for label, data in sessions.items():
         session_type = data.get("session_type", "session")
         if session_type == "workspace":
-            # For workspaces, collect all repo names
-            workspace_repos = data.get("workspace_repos", [])
-            for repo_data in workspace_repos:
-                all_repos.add(repo_data['repo_name'])
+            # For workspaces, just add the workspace name
+            all_repos.add(f"workspace-{label}")
         else:
             # For regular sessions, use repository name
             all_repos.add(data['repository_name'])
@@ -551,16 +549,14 @@ def open_control_center():
         session_type = data.get("session_type", "session")
 
         if session_type == "workspace":
-            # For workspaces, create separate windows for each repo
-            workspace_repos = data.get("workspace_repos", [])
-            for repo_data in workspace_repos:
-                repo_name = repo_data['repo_name']
-                name = f"{label}-{repo_name}" if include_repo_name else f"{label}-{repo_name}"
-                active_contexts.append({
-                    "name": name,
-                    "path": repo_data["worktree_path"],
-                    "type": "workspace"
-                })
+            # For workspaces, create single window starting from workspace root
+            workspace_root = data["repository_path"]  # This is the workspace root directory
+            name = f"workspace-{label}" if include_repo_name else label
+            active_contexts.append({
+                "name": name,
+                "path": workspace_root,
+                "type": "workspace"
+            })
         else:
             # For regular sessions, create single window
             repo_name = data['repository_name']

--- a/par/core.py
+++ b/par/core.py
@@ -54,20 +54,20 @@ def _migrate_legacy_state() -> Dict[str, Any]:
     """Migrate from old per-repo state files to global state."""
     legacy_state_file = utils.get_data_dir() / "state.json"
     legacy_workspace_file = utils.get_data_dir() / "workspaces.json"
-    
+
     migrated = {"sessions": {}, "workspaces": {}}
-    
+
     # Migrate legacy sessions
     if legacy_state_file.exists():
         try:
             with open(legacy_state_file, "r") as f:
                 content = f.read().strip()
                 legacy_state = json.loads(content) if content else {}
-                
+
             for repo_path, repo_sessions in legacy_state.items():
                 repo_path_obj = Path(repo_path)
                 repo_name = repo_path_obj.name
-                
+
                 for label, session_data in repo_sessions.items():
                     # Create globally unique label if collision
                     global_label = label
@@ -75,7 +75,7 @@ def _migrate_legacy_state() -> Dict[str, Any]:
                     while global_label in migrated["sessions"]:
                         global_label = f"{label}-{repo_name.lower()}-{counter}"
                         counter += 1
-                    
+
                     migrated["sessions"][global_label] = {
                         "label": global_label,
                         "repository_path": repo_path,
@@ -89,25 +89,25 @@ def _migrate_legacy_state() -> Dict[str, Any]:
                     }
         except (json.JSONDecodeError, FileNotFoundError):
             pass
-    
+
     # Migrate legacy workspaces
     if legacy_workspace_file.exists():
         try:
             with open(legacy_workspace_file, "r") as f:
                 content = f.read().strip()
                 legacy_workspaces = json.loads(content) if content else {}
-                
+
             for workspace_root, workspace_sessions in legacy_workspaces.items():
                 for label, workspace_data in workspace_sessions.items():
                     # Create globally unique label if collision
                     global_label = label
                     counter = 1
-                    while (global_label in migrated["sessions"] or 
+                    while (global_label in migrated["sessions"] or
                            global_label in migrated["workspaces"]):
                         workspace_name = Path(workspace_root).name
                         global_label = f"{label}-{workspace_name.lower()}-{counter}"
                         counter += 1
-                    
+
                     migrated["workspaces"][global_label] = {
                         "label": global_label,
                         "workspace_root": workspace_data["workspace_root"],
@@ -117,19 +117,19 @@ def _migrate_legacy_state() -> Dict[str, Any]:
                     }
         except (json.JSONDecodeError, FileNotFoundError):
             pass
-    
+
     # If we migrated anything, backup the old files
     if migrated["sessions"] or migrated["workspaces"]:
         backup_dir = utils.get_data_dir() / "backup"
         backup_dir.mkdir(exist_ok=True)
-        
+
         if legacy_state_file.exists():
             shutil.copy2(legacy_state_file, backup_dir / "state.json.backup")
         if legacy_workspace_file.exists():
             shutil.copy2(legacy_workspace_file, backup_dir / "workspaces.json.backup")
-            
+
         typer.secho(f"Migrated legacy state files. Backups saved to {backup_dir}", fg="green")
-    
+
     return migrated
 
 
@@ -182,7 +182,7 @@ def start_session(label: str, repo_path: Optional[str] = None, open_session: boo
     # Resolve repository path
     repo_root = utils.resolve_repository_path(repo_path)
     repo_name = repo_root.name
-    
+
     worktree_path = utils.get_worktree_path(repo_root, label)
     session_name = utils.get_tmux_session_name(repo_root, label)
 
@@ -244,7 +244,7 @@ def remove_session(label: str):
         raise typer.Exit(1)
 
     session_type = session_data.get("session_type", "session")
-    
+
     # Handle workspace sessions differently
     if session_type == "workspace":
         _remove_workspace_session(session_data)
@@ -316,7 +316,7 @@ def _get_workspace(label: str) -> Optional[Dict[str, Any]]:
 def remove_all_sessions():
     """Remove all sessions (including workspaces) globally."""
     sessions = _get_all_sessions()
-    
+
     if not sessions:
         typer.secho("No sessions to remove.", fg="yellow")
         return
@@ -324,13 +324,13 @@ def remove_all_sessions():
     # Separate regular sessions from workspaces for display
     regular_sessions = {k: v for k, v in sessions.items() if v.get("session_type") != "workspace"}
     workspace_sessions = {k: v for k, v in sessions.items() if v.get("session_type") == "workspace"}
-    
+
     typer.echo(f"This will remove {len(regular_sessions)} sessions and {len(workspace_sessions)} workspaces:")
     for label in regular_sessions:
         typer.echo(f"  Session: {label}")
     for label in workspace_sessions:
         typer.echo(f"  Workspace: {label}")
-        
+
     typer.confirm(f"Remove all {len(sessions)} items?", abort=True)
 
     # Remove all sessions (including workspaces)
@@ -394,7 +394,7 @@ def list_sessions():
         )
 
         session_type = data.get("session_type", "session")
-        
+
         if session_type == "workspace":
             # Display workspace info
             workspace_repos = data.get("workspace_repos", [])
@@ -403,7 +403,7 @@ def list_sessions():
         else:
             # Display regular session info
             repo_display = f"{data['repository_name']} ({Path(data['repository_path']).parent.name})"
-        
+
         table.add_row(
             label,
             session_type.title(),
@@ -462,7 +462,7 @@ def checkout_session(target: str, custom_label: Optional[str] = None, repo_path:
     # Resolve repository path
     repo_root = utils.resolve_repository_path(repo_path)
     repo_name = repo_root.name
-    
+
     worktree_path = utils.get_worktree_path(repo_root, label)
     session_name = utils.get_tmux_session_name(repo_root, label)
 
@@ -516,61 +516,29 @@ def checkout_session(target: str, custom_label: Optional[str] = None, repo_path:
 
 
 def open_control_center():
-    """Open all sessions (including workspaces) in a tiled tmux layout."""
+    """Create a new 'control-center' tmux session with separate windows for each par session."""
+
+    # Get all sessions from global state (includes both regular sessions and workspaces)
     sessions = _get_all_sessions()
 
     if not sessions:
-        typer.secho("No sessions to display.", fg="yellow")
+        typer.secho("No sessions or workspaces to display.", fg="yellow")
         return
-
-    # Prepare all contexts for control center
-    active_contexts = []
-
-    # Add all sessions (including workspaces)
-    for label, data in sessions.items():
-        session_name = data["tmux_session_name"]
-        session_type = data.get("session_type", "session")
-        
-        if not operations.tmux_session_exists(session_name):
-            typer.secho(f"Recreating {session_type} '{label}'...", fg="yellow")
-            
-            if session_type == "workspace":
-                # For workspaces, recreate from workspace root
-                workspace_root = Path(data["repository_path"])
-                operations.create_tmux_session(session_name, workspace_root)
-            else:
-                # For regular sessions, recreate from worktree path
-                operations.create_tmux_session(session_name, Path(data["worktree_path"]))
-        
-        active_contexts.append({
-            "tmux_session_name": session_name,
-            "worktree_path": data["worktree_path"]
-        })
-
-    operations.open_control_center(active_contexts)
-
-def open_control_center_new():
-    """Create a new 'control-center' tmux session with separate windows for each par session."""
-
-    # Get all repository sessions across all repos
-    all_repo_sessions = _load_state()
-
-    # Get all workspace sessions across all directories
-    all_workspace_sessions = workspace._load_workspace_state()
 
     # Collect all repositories to determine naming strategy
     all_repos = set()
 
-    # Collect repo names from single-repo sessions
-    for repo_path, repo_sessions in all_repo_sessions.items():
-        repo_name = Path(repo_path).name
-        all_repos.add(repo_name)
-
-    # Collect repo names from workspace sessions
-    for workspace_dir, workspaces in all_workspace_sessions.items():
-        for ws_label, ws_data in workspaces.items():
-            for repo_data in ws_data.get("repos", []):
+    # Collect repo names from all sessions
+    for label, data in sessions.items():
+        session_type = data.get("session_type", "session")
+        if session_type == "workspace":
+            # For workspaces, collect all repo names
+            workspace_repos = data.get("workspace_repos", [])
+            for repo_data in workspace_repos:
                 all_repos.add(repo_data['repo_name'])
+        else:
+            # For regular sessions, use repository name
+            all_repos.add(data['repository_name'])
 
     # Determine if we need to include repo names (more than one unique repo)
     include_repo_name = len(all_repos) > 1
@@ -578,10 +546,24 @@ def open_control_center_new():
     # Prepare all contexts for control center
     active_contexts = []
 
-    # Add all single-repo sessions
-    for repo_path, repo_sessions in all_repo_sessions.items():
-        repo_name = Path(repo_path).name
-        for label, data in repo_sessions.items():
+    # Process all sessions
+    for label, data in sessions.items():
+        session_type = data.get("session_type", "session")
+
+        if session_type == "workspace":
+            # For workspaces, create separate windows for each repo
+            workspace_repos = data.get("workspace_repos", [])
+            for repo_data in workspace_repos:
+                repo_name = repo_data['repo_name']
+                name = f"{label}-{repo_name}" if include_repo_name else f"{label}-{repo_name}"
+                active_contexts.append({
+                    "name": name,
+                    "path": repo_data["worktree_path"],
+                    "type": "workspace"
+                })
+        else:
+            # For regular sessions, create single window
+            repo_name = data['repository_name']
             name = f"{repo_name}-{label}" if include_repo_name else label
             active_contexts.append({
                 "name": name,
@@ -589,19 +571,4 @@ def open_control_center_new():
                 "type": "session"
             })
 
-    # Add all workspace sessions - create separate windows for each repo in each workspace
-    for workspace_dir, workspaces in all_workspace_sessions.items():
-        for ws_label, ws_data in workspaces.items():
-            for repo_data in ws_data.get("repos", []):
-                name = f"{ws_label}-{repo_data['repo_name']}" if include_repo_name else ws_label
-                active_contexts.append({
-                    "name": name,
-                    "path": repo_data["worktree_path"],
-                    "type": "workspace"
-                })
-
-    if not active_contexts:
-        typer.secho("No sessions or workspaces to display.", fg="yellow")
-        return
-
-    operations.open_control_center_new(active_contexts)
+    operations.open_control_center(active_contexts)


### PR DESCRIPTION
This PR re-architects the control-center UX. Instead of nesting tmux sessions, which I find hard to manage, we instead create new tmux windows for each par session, globally across all sessions/workspaces.

For example, if you have two session started in repo-a, we'll open up those two sessions in two separate windows, when you open `control-center`.

Demo on the new control-center UX:
https://github.com/user-attachments/assets/f4b17610-d663-4edd-81e0-3713e8bf6ba9
