### PR TITLE
POC: New globally managed par state manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Easily manage parallel development workflows with isolated Git worktrees and tmux sessions**
 
-`par` is a command-line tool designed to simplify parallel development within a single Git repository. It's specifically designed for working with AI coding assistants, background agents, or multiple development contexts simultaneously, `par` creates isolated workspaces that don't interfere with each other.
+`par` is a **global** command-line tool designed to simplify parallel development across any Git repositories on your system. It's specifically designed for working with AI coding assistants, background agents, or multiple development contexts simultaneously, `par` creates isolated workspaces that don't interfere with each other.
 
 ## Why Par?
 
@@ -12,8 +12,9 @@ Tools like OpenAI Codex, Claude Code, and other coding agents have made it easie
 
 - **🔀 Git Worktrees**: Each session gets its own directory and branch
 - **🖥️ Tmux Sessions**: Persistent terminal sessions where agents can run in the background
-- **🏷️ Simple Labels**: Easy-to-remember names for each session
-- **📡 Remote Control**: Send commands to any or all sessions
+- **🏷️ Globally Unique Labels**: Easy-to-remember names that work across all repositories
+- **🌍 Global Management**: Create, list, and manage sessions from anywhere on your system
+- **📡 Remote Control**: Send commands to any or all sessions globally
 - **👁️ Overview Mode**: Monitor all sessions simultaneously
 - **🏢 Multi-Repo Workspaces**: Unified development across multiple repositories
 - **🎨 IDE Integration**: Native VSCode/Cursor workspace support with auto-generated configs
@@ -26,27 +27,30 @@ https://github.com/user-attachments/assets/88eb4aed-c00d-4238-b1a9-bcaa34c975c3
 
 ### 🚀 **Quick Start**
 ```bash
+# From within a git repository
 par start feature-auth    # Creates worktree, branch, and tmux session
-par start bugfix-login    # Another isolated session
-par start experiment-ai   # Yet another session
+
+# From anywhere on your system
+par start bugfix-login --path /path/to/repo
+par start experiment-ai --path ~/projects/my-app
 ```
 
-### 📋 **Unified Development Context Management**
+### 📋 **Global Development Context Management**
 ```bash
-par ls                    # List all sessions AND workspaces in one view
-par open feature-auth     # Switch to any session or workspace
-par rm bugfix-login       # Clean up completed work
+par ls                    # List ALL sessions and workspaces globally
+par open feature-auth     # Switch to any session or workspace from anywhere
+par rm bugfix-login       # Clean up completed work globally
 ```
 
-### 📡 **Remote Execution**  
+### 📡 **Global Remote Execution**  
 ```bash
 par send feature-auth "pnpm test"           # Run tests in one session
-par send all "git status"                  # Check status across all sessions
+par send all "git status"                  # Check status across ALL sessions globally
 ```
 
-### 🎛️ **Control Center**
+### 🎛️ **Global Control Center**
 ```bash
-par control-center        # View all sessions AND workspaces in a tiled layout
+par control-center        # View ALL sessions and workspaces globally in a tiled layout
 ```
 
 ### 🏢 **Multi-Repository Workspaces**
@@ -112,14 +116,19 @@ par --help
 Create a new isolated development environment:
 
 ```bash
-cd /path/to/your/git/repo
+# From within a git repository
 par start my-feature
+
+# From anywhere, specifying the repository path
+par start my-feature --path /path/to/your/git/repo
+par start my-feature -p ~/projects/my-app
 ```
 
 This creates:
 - Git worktree at `~/.local/share/par/worktrees/<repo-hash>/my-feature/`
 - Git branch named `my-feature`
 - tmux session named `par-<repo>-<hash>-my-feature`
+- **Globally unique session** accessible from anywhere
 
 ### Checking Out Existing Branches and PRs
 
@@ -140,6 +149,10 @@ par checkout alice:feature-branch
 
 # Checkout with custom session label
 par checkout develop --label dev-work
+
+# Checkout from anywhere specifying repository path
+par checkout feature-branch --path /path/to/repo
+par checkout pr/123 --path ~/projects/my-app --label pr-review
 ```
 
 **Supported formats:**
@@ -149,66 +162,67 @@ par checkout develop --label dev-work
 - `username:branch` - Remote branch from fork
 - `remote/branch` - Branch from specific remote
 
-### Managing Development Contexts
+### Global Development Context Management
 
-**List all sessions and workspaces:**
+**List all sessions and workspaces globally:**
 ```bash
-par ls
+par ls    # Shows ALL sessions and workspaces from anywhere
 ```
 
-Shows both single-repo sessions and multi-repo workspaces in a unified table:
+Shows all development contexts across all repositories in a unified table:
 
 ```
-Par Development Contexts for coplane:
+Par Development Contexts (Global)
 
 ┌────────────────┬───────────┬──────────────────┬──────────────┬─────────────────┬────────────┐
-│ Label          │ Type      │ Tmux Session     │ Branch       │ Other Repos     │ Created    │
+│ Label          │ Type      │ Repository/Work… │ Tmux Session │ Branch          │ Created    │
 ├────────────────┼───────────┼──────────────────┼──────────────┼─────────────────┼────────────┤
-│ feature-auth   │ Session   │ par-coplane-...  │ feature-auth │ -               │ 2025-06-07 │
-│ fullstack-auth │ Workspace │ par-ws-coplane.. │ fullstack-auth│ planar          │ 2025-06-05 │
+│ feature-auth   │ Session   │ my-app (proj…)   │ par-myapp-…  │ feature-auth    │ 2025-07-19 │
+│ fullstack      │ Workspace │ workspace (2 re… │ par-ws-full… │ fullstack       │ 2025-07-19 │
+│ bugfix-123     │ Checkout  │ other-repo (c…)  │ par-other-…  │ hotfix/bug-123  │ 2025-07-19 │
 └────────────────┴───────────┴──────────────────┴──────────────┴─────────────────┴────────────┘
 ```
 
-**Open any development context:**
+**Open any development context from anywhere:**
 ```bash
-par open my-feature        # Opens single-repo session
-par open fullstack-auth    # Opens multi-repo workspace
+par open my-feature        # Opens session (works globally)
+par open fullstack-auth    # Opens workspace (works globally)
 ```
 
-**Remove completed work:**
+**Remove completed work from anywhere:**
 ```bash
-par rm my-feature      # Remove specific session/workspace
-par rm all             # Remove all sessions (with confirmation)
+par rm my-feature      # Remove specific session/workspace globally
+par rm all             # Remove ALL sessions and workspaces (with confirmation)
 ```
 
 > **Note**: When removing checkout sessions, `par` only removes the worktree and tmux session. It does not delete the original branch since it wasn't created by `par`.
 
-### Remote Command Execution
+### Global Remote Command Execution
 
-**Send commands to specific sessions:**
+**Send commands to specific sessions (works globally):**
 ```bash
 par send my-feature "npm install"
 par send backend-work "python manage.py migrate"
-par send docs-update "mkdocs serve"
+par send workspace-name "git status"    # Works for workspaces too
 ```
 
-**Broadcast to all sessions:**
+**Broadcast to ALL sessions and workspaces globally:**
 ```bash
-par send all "git status"
-par send all "npm test"
+par send all "git status"    # Sends to every session everywhere
+par send all "npm test"      # Runs tests across all contexts
 ```
 
-### Control Center
+### Global Control Center
 
-View all development contexts simultaneously in a tiled tmux layout:
+View ALL development contexts simultaneously in a tiled tmux layout:
 
 ```bash
-par control-center
+par control-center    # Works from anywhere, shows everything
 ```
 
-Shows both single-repo sessions and multi-repo workspaces in separate panes, giving you a unified overview of all your active development work.
+Shows all sessions and workspaces across all repositories in separate panes, giving you a unified overview of your entire development workflow.
 
-> **Note**: Must be run from outside tmux. Creates a new session and attaches to each context in its own pane.
+> **Note**: Must be run from outside tmux. Creates a global control center session with all contexts visible.
 
 ### Automatic Initialization with .par.yaml
 
@@ -242,7 +256,7 @@ When you run `par start my-feature`, these commands will automatically execute i
 
 ## Multi-Repository Workspaces
 
-For projects spanning multiple repositories (like frontend/backend splits or microservices), `par` provides **workspace** functionality that manages multiple repositories together in a unified development environment.
+For projects spanning multiple repositories (like frontend/backend splits or microservices), `par` provides **workspace** functionality that creates a single session managing multiple repositories together in a unified development environment.
 
 ### Why Workspaces?
 
@@ -252,19 +266,18 @@ When working on features that span multiple repositories, you typically need to:
 - Switch between repositories frequently
 - Manage development servers for multiple services
 
-Workspaces solve this by creating a single tmux session with dedicated panes for each repository, all sharing the same branch name.
+Workspaces solve this by creating a **single global session** that starts from a unified workspace directory with access to all repositories, all sharing the same branch name.
 
 ### Quick Start
 
 ```bash
-# Navigate to directory containing multiple repos
+# From a directory containing multiple repos (auto-detection)
 cd /path/to/my-project     # contains frontend/, backend/, docs/
-
-# Start workspace with auto-detection
 par workspace start feature-auth
 
-# Or specify repositories explicitly
-par workspace start feature-auth --repos frontend,backend
+# From anywhere, specifying repositories by absolute path
+par workspace start feature-auth --repos /path/to/frontend,/path/to/backend
+par workspace start feature-auth --path /workspace/root --repos frontend,backend
 
 # Open in your preferred IDE with proper multi-repo support
 par workspace code feature-auth     # VSCode
@@ -275,47 +288,58 @@ par workspace cursor feature-auth   # Cursor
 
 **Create a workspace:**
 ```bash
-par workspace start <label> [--repos repo1,repo2] [--open]
+par workspace start <label> [--path /workspace/root] [--repos repo1,repo2] [--open]
 ```
 
-**List workspaces:**
+**List workspaces (now unified with sessions):**
 ```bash
-par workspace ls
+par ls                            # Shows workspaces alongside sessions
+par workspace ls                  # Shows only workspaces (deprecated)
 ```
 
-**Open workspace:**
+**Open workspace (now unified):**
 ```bash
-par workspace open <label>        # Attach to tmux session
+par open <label>                  # Opens workspace session (works globally)
 par workspace code <label>        # Open in VSCode  
 par workspace cursor <label>      # Open in Cursor
 ```
 
-**Remove workspace:**
+**Remove workspace (now unified):**
 ```bash
-par workspace rm <label>          # Remove specific workspace
-par workspace rm all              # Remove all workspaces
+par rm <label>                    # Remove workspace (works globally)
+par workspace rm <label>          # Also works (delegates to global rm)
 ```
 
 ### How Workspaces Work
 
 When you create a workspace, `par` automatically:
 
-1. **Detects repositories** in the current directory (or uses `--repos`)
+1. **Detects repositories** in the workspace directory (or uses `--repos` with absolute paths)
 2. **Creates worktrees** for each repository with the same branch name
-3. **Creates tmux session** in the workspace root directory with access to all repositories
+3. **Creates single global session** starting from unified workspace root with access to all repositories
 4. **Generates IDE workspace files** for seamless editor integration
+5. **Integrates with global par commands** - use `par ls`, `par open`, `par rm` etc.
 
 **Example directory structure:**
 ```
-my-fullstack-app/
-├── frontend/           # React app
-├── backend/            # Python API  
-└── docs/              # Documentation
+# Original repositories anywhere on system:
+/home/user/projects/frontend/     # React app
+/home/user/projects/backend/      # Python API  
+/opt/company/docs/                # Documentation
 
-# After: par workspace start user-auth
-# Creates branches: user-auth in all three repos
-# Creates single tmux session in workspace root
-# Can access all repositories with: cd frontend/, cd backend/, cd docs/
+# After: par workspace start user-auth --repos /home/user/projects/frontend,/home/user/projects/backend,/opt/company/docs
+# Creates unified workspace at: ~/.local/share/par/workspaces/.../user-auth/
+├── frontend/
+│   └── user-auth/     # Worktree with user-auth branch
+├── backend/
+│   └── user-auth/     # Worktree with user-auth branch  
+├── docs/
+│   └── user-auth/     # Worktree with user-auth branch
+└── user-auth.code-workspace
+
+# Single tmux session starts from workspace root
+# Navigate with: cd frontend/, cd backend/, cd docs/
+# Global session accessible via: par open user-auth (from anywhere)
 ```
 
 ### IDE Integration
@@ -421,34 +445,38 @@ Each repository's initialization runs in its own worktree, ensuring proper isola
 
 **Full-stack feature development:**
 ```bash
-# 1. Start workspace for new feature
-cd my-app/
-par workspace start user-profiles --repos frontend,backend
+# 1. Start workspace for new feature (from anywhere)
+par workspace start user-profiles --repos /path/to/frontend,/path/to/backend
 
 # 2. Open in IDE with proper multi-repo support
 par workspace code user-profiles
 
-# 3. Open tmux session in workspace root
-par workspace open user-profiles
+# 3. Open unified session (works globally)
+par open user-profiles
 
 # 4. Work across repositories from single terminal
 cd frontend/    # Switch to frontend worktree
 cd ../backend/  # Switch to backend worktree
 claude          # Run Claude from workspace root to see all repos
 
-# 5. Clean up when feature is complete
-par workspace rm user-profiles
+# 5. Global management (works from anywhere)
+par ls                           # See all sessions including workspaces
+par send user-profiles "git status"  # Send commands globally
+
+# 6. Clean up when feature is complete (from anywhere)
+par rm user-profiles
 ```
 
 **Microservices development:**
 ```bash
-# Work on API changes affecting multiple services
-par workspace start api-v2 --repos auth-service,user-service,gateway
+# Work on API changes affecting multiple services (absolute paths)
+par workspace start api-v2 --repos /srv/auth-service,/srv/user-service,/srv/gateway
 
 # All services get api-v2 branch
-# Single tmux session in workspace root
-# IDE workspace shows all services together
-# Navigate between services: cd auth-service/, cd user-service/, etc.
+# Single global session accessible from anywhere
+# IDE workspace shows all services together  
+# Navigate: cd auth-service/, cd user-service/, etc.
+# Global commands: par send api-v2 "docker-compose up"
 ```
 
 ### Branch Creation
@@ -461,16 +489,19 @@ Workspaces create branches from the **currently checked out branch** in each rep
 
 ## Advanced Usage
 
-### Repository-Scoped Sessions
+### Globally Unique Sessions
 
-`par` automatically scopes sessions to the current Git repository. You can use the same labels across different projects without conflicts:
+`par` enforces globally unique session labels across all repositories. This ensures you can manage sessions from anywhere without conflicts:
 
 ```bash
-cd ~/project-a
-par start feature-auth    # Creates project-a/feature-auth
+# All sessions must have unique labels globally
+par start feature-auth --path ~/project-a    # Creates feature-auth session
+par start feature-auth --path ~/project-b    # ❌ Error: label already exists
+par start feature-auth-v2 --path ~/project-b # ✅ Works with unique label
 
-cd ~/project-b  
-par start feature-auth    # Creates separate project-b/feature-auth
+# Access any session from anywhere
+par open feature-auth      # Works from any directory
+par ls                     # Shows all sessions globally
 ```
 
 ## Configuration
@@ -480,12 +511,20 @@ Par stores its data in `~/.local/share/par/` (or `$XDG_DATA_HOME/par/`):
 
 ```
 ~/.local/share/par/
-├── state.json              # Session metadata
-└── worktrees/              # Git worktrees organized by repo
-    └── <repo-hash>/
-        ├── feature-1/      # Individual workspaces
-        ├── feature-2/
-        └── experiment-1/
+├── global_state.json       # Global session and workspace metadata
+├── worktrees/              # Single-repo sessions organized by repo hash
+│   └── <repo-hash>/
+│       ├── feature-1/      # Individual worktrees
+│       ├── feature-2/
+│       └── experiment-1/
+└── workspaces/             # Multi-repo workspaces
+    └── <workspace-hash>/
+        └── <workspace-label>/
+            ├── frontend/
+            │   └── feature-auth/     # Worktree
+            ├── backend/
+            │   └── feature-auth/     # Worktree  
+            └── feature-auth.code-workspace
 ```
 
 ### Session Naming Convention
@@ -495,9 +534,9 @@ Example: `par-myproject-a1b2c3d4-feature-auth`
 
 ### Cleaning Up
 
-Remove all par-managed resources for the current repository:
+Remove all par-managed resources globally:
 ```bash
-par rm all
+par rm all    # Removes ALL sessions and workspaces everywhere
 ```
 
 Remove specific stale sessions:

--- a/par/cli.py
+++ b/par/cli.py
@@ -16,17 +16,9 @@ app = typer.Typer(
 def get_session_labels() -> List[str]:
     """Get list of all session and workspace labels for autocomplete."""
     try:
-        labels = []
-
-        # Add all sessions globally
+        # All sessions now include workspaces (with session_type="workspace")
         sessions = core._get_all_sessions()
-        labels.extend(sessions.keys())
-
-        # Add all workspaces globally 
-        workspaces = core._get_all_workspaces()
-        labels.extend(workspaces.keys())
-
-        return labels
+        return list(sessions.keys())
     except Exception:
         return []
 

--- a/par/cli.py
+++ b/par/cli.py
@@ -14,26 +14,17 @@ app = typer.Typer(
 
 
 def get_session_labels() -> List[str]:
-    """Get list of session and workspace labels for autocomplete."""
+    """Get list of all session and workspace labels for autocomplete."""
     try:
         labels = []
 
-        # Add single-repo sessions
-        sessions = core._get_repo_sessions()
+        # Add all sessions globally
+        sessions = core._get_all_sessions()
         labels.extend(sessions.keys())
 
-        # Add workspaces that contain current repo
-        current_repo_root = core.utils.get_git_repo_root()
-        current_repo_name = current_repo_root.name
-        current_dir = current_repo_root.parent
-        workspace_sessions = workspace._get_workspace_sessions(current_dir)
-
-        for ws_label, ws_data in workspace_sessions.items():
-            # Check if this workspace contains the current repository
-            for repo_data in ws_data.get("repos", []):
-                if repo_data["repo_name"] == current_repo_name:
-                    labels.append(ws_label)
-                    break
+        # Add all workspaces globally 
+        workspaces = core._get_all_workspaces()
+        labels.extend(workspaces.keys())
 
         return labels
     except Exception:
@@ -74,9 +65,16 @@ def start(
     label: Annotated[
         str,
         typer.Argument(
-            help="A unique label for the new worktree, branch, and tmux session."
+            help="A globally unique label for the new worktree, branch, and tmux session."
         ),
     ],
+    path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--path", "-p",
+            help="Path to git repository (defaults to current directory)"
+        ),
+    ] = None,
     open_session: Annotated[
         bool,
         typer.Option(
@@ -87,12 +85,13 @@ def start(
     """
     Start a new git worktree and tmux session.
     Creates a worktree, a git branch (both named <label>), and a tmux session.
+    Labels must be globally unique across all repositories.
     """
-    core.start_session(label, open_session=open_session)
+    core.start_session(label, repo_path=path, open_session=open_session)
 
 
 def get_session_labels_with_all() -> List[str]:
-    """Get list of session and workspace labels plus 'all' for autocomplete."""
+    """Get list of all session and workspace labels plus 'all' for autocomplete."""
     try:
         labels = get_session_labels()  # Reuse the unified function
         labels.append("all")
@@ -158,20 +157,28 @@ def checkout(
             help="Branch name, PR number (pr/123), PR URL, or remote branch (user:branch)"
         ),
     ],
+    path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--path", "-p",
+            help="Path to git repository (defaults to current directory)"
+        ),
+    ] = None,
     label: Annotated[
         Optional[str],
         typer.Option(
             "--label",
             "-l",
-            help="Custom label for the session (defaults to branch name)",
+            help="Custom globally unique label for the session (defaults to branch name)",
         ),
     ] = None,
 ):
     """
     Checkout an existing branch or PR into a new par session.
     Creates a worktree from existing branch/PR without creating a new branch.
+    Labels must be globally unique across all repositories.
     """
-    core.checkout_session(target, label)
+    core.checkout_session(target, custom_label=label, repo_path=path)
 
 
 @app.command()
@@ -209,8 +216,15 @@ app.add_typer(workspace_app, name="workspace")
 def workspace_start(
     label: Annotated[
         str,
-        typer.Argument(help="A unique label for the workspace"),
+        typer.Argument(help="A globally unique label for the workspace"),
     ],
+    path: Annotated[
+        Optional[str],
+        typer.Option(
+            "--path", "-p",
+            help="Path to workspace directory (defaults to current directory)"
+        ),
+    ] = None,
     repos: Annotated[
         Optional[str],
         typer.Option(
@@ -227,13 +241,14 @@ def workspace_start(
     """
     Start a new multi-repository workspace.
     Creates worktrees and branches for multiple repos in a single tmux session.
+    Labels must be globally unique across all repositories and workspaces.
     """
     # Parse comma-separated repos
     repo_list = None
     if repos:
         repo_list = [r.strip() for r in repos.split(",") if r.strip()]
 
-    workspace.start_workspace_session(label, repo_list, open_session)
+    workspace.start_workspace_session(label, workspace_path=path, repos=repo_list, open_session=open_session)
 
 
 @workspace_app.command("ls")

--- a/par/operations.py
+++ b/par/operations.py
@@ -24,9 +24,11 @@ def _check_tmux():
 
 
 # Git operations
-def create_worktree(label: str, worktree_path: Path, base_branch: Optional[str] = None):
+def create_worktree(label: str, worktree_path: Path, repo_root: Optional[Path] = None, base_branch: Optional[str] = None):
     """Create a new git worktree and branch."""
-    repo_root = get_git_repo_root()
+    if repo_root is None:
+        repo_root = get_git_repo_root()
+    
     cmd = ["git", "worktree", "add", "-b", label, str(worktree_path)]
     if base_branch:
         cmd.append(base_branch)
@@ -39,9 +41,11 @@ def create_worktree(label: str, worktree_path: Path, base_branch: Optional[str] 
         raise typer.Exit(1)
 
 
-def remove_worktree(worktree_path: Path):
+def remove_worktree(worktree_path: Path, repo_root: Optional[Path] = None):
     """Remove a git worktree."""
-    repo_root = get_git_repo_root()
+    if repo_root is None:
+        repo_root = get_git_repo_root()
+    
     cmd = ["git", "worktree", "remove", "--force", str(worktree_path)]
 
     try:
@@ -53,10 +57,11 @@ def remove_worktree(worktree_path: Path):
 
 
 def checkout_worktree(
-    branch_name: str, worktree_path: Path, strategy: CheckoutStrategy
+    branch_name: str, worktree_path: Path, strategy: CheckoutStrategy, repo_root: Optional[Path] = None
 ):
     """Create worktree from existing branch."""
-    repo_root = get_git_repo_root()
+    if repo_root is None:
+        repo_root = get_git_repo_root()
 
     # Handle PR fetching specially
     if strategy.is_pr:
@@ -108,9 +113,11 @@ def checkout_worktree(
         raise typer.Exit(1)
 
 
-def delete_branch(branch_name: str):
+def delete_branch(branch_name: str, repo_root: Optional[Path] = None):
     """Delete a git branch."""
-    repo_root = get_git_repo_root()
+    if repo_root is None:
+        repo_root = get_git_repo_root()
+    
     cmd = ["git", "branch", "-D", branch_name]
 
     try:
@@ -204,8 +211,8 @@ def open_control_center(sessions_data: List[dict]):
         typer.secho("No sessions to display.", fg="yellow")
         return
 
-    repo_root = get_git_repo_root()
-    cc_session_name = get_tmux_session_name(repo_root, "cc")
+    # Use a global control center session name
+    cc_session_name = "par-control-center"
 
     # Check if control center already exists
     if tmux_session_exists(cc_session_name):

--- a/par/utils.py
+++ b/par/utils.py
@@ -187,3 +187,39 @@ def get_workspace_file_path(workspace_root: Path, workspace_label: str) -> Path:
     workspace_dir = get_data_dir() / "workspaces" / workspace_id / workspace_label
     workspace_dir.mkdir(parents=True, exist_ok=True)
     return workspace_dir / f"{workspace_label}.code-workspace"
+
+
+def save_vscode_workspace_file(workspace_label: str, repos_data: List[Dict]) -> Path:
+    """Generate and save a VSCode workspace file."""
+    import json
+    
+    # Generate workspace configuration
+    workspace_config = generate_vscode_workspace(workspace_label, repos_data)
+    
+    # Determine workspace root from first repository
+    if repos_data:
+        first_repo_path = Path(repos_data[0]["repo_path"])
+        workspace_root = first_repo_path.parent
+    else:
+        workspace_root = Path.cwd()
+    
+    # Get file path and save
+    workspace_file = get_workspace_file_path(workspace_root, workspace_label)
+    
+    with open(workspace_file, "w") as f:
+        json.dump(workspace_config, f, indent=2)
+    
+    return workspace_file
+
+
+def resolve_repository_path(path: Optional[str] = None) -> Path:
+    """Resolve repository path from optional parameter or current directory."""
+    if path:
+        repo_path = Path(path).resolve()
+        if not (repo_path / ".git").exists():
+            import typer
+            typer.secho(f"Error: '{repo_path}' is not a git repository.", fg="red", err=True)
+            raise typer.Exit(1)
+        return repo_path
+    else:
+        return get_git_repo_root()

--- a/par/workspace.py
+++ b/par/workspace.py
@@ -196,6 +196,7 @@ def list_workspace_sessions():
         session_name = data["tmux_session_name"]
         created = data.get("created_at", "Unknown")
         if created != "Unknown":
+            # Format datetime to be more readable
             try:
                 dt = datetime.datetime.fromisoformat(created)
                 created = dt.strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
## High Level
This is a POC PR to showcase how `par` could be re-architected to use a globally aware state manager instead of a repo-scoped state manager. 

## Motivation

Right now, `par` sits at a level very close to `git`, in that your sessions should generally be managed next to your git repos. This works when you only interact with `par` in the repo (or workspace). However, this means you aren't able to manage your par sessions from anywhere outside of that repo. For example, if you start a new shell and want to re-open an existing `par` session, you must first navigate to the repo, then `par ls` to find the name, then `par open <label>`. 

## Overview

This PR proposes, moving all `par` state management to a global config, so that you can see all sessions `par` is managing across all of your repos and workspaces. With this change, you can run `par ls` and see any session that's been created. This makes it much easier to navigate between the different sessions `par` is aware of.

This global config management, does in a way, take over some of the responsibility of workspaces, since you no longer need to use a workspace to easily manage and access multiple repos, however, there's still one core functionality workspaces provide, in that, all workspace repos worktrees share a parent directory. This enables us to start a single claude-code and editor session from the workspace directory, that stays scoped to the branch, across both repos.

## Demo

https://github.com/user-attachments/assets/a7a16886-69da-4e16-b836-c85eed9e15e1
